### PR TITLE
Export button working mostly as intended  💯 

### DIFF
--- a/src/main/java/SequenceExporter.java
+++ b/src/main/java/SequenceExporter.java
@@ -1,5 +1,4 @@
 import org.apache.log4j.Logger;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -8,11 +7,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.ArrayList;
-import java.util.HashMap;
 
 /**
  * Created by David Huculak on 2017-02-02.
@@ -20,6 +16,8 @@ import java.util.HashMap;
 public class SequenceExporter extends HttpServlet {
 
     private static Logger logger = Logger.getLogger("SequenceExporter");
+
+    private final String EXPORTS_DIR = "/opt/tomcat/webapps/courseplanner/exports/";
 
     public void doPost(HttpServletRequest request,
                        HttpServletResponse response)
@@ -30,15 +28,107 @@ public class SequenceExporter extends HttpServlet {
 
         ArrayList<Semester> semesters = Util.grabSemestersFromRequest(request);
 
-        logger.info(semesters.get(3).isWorkTerm());
+        String semesterAsMarkdown = semesterListToMarkdownString(semesters);
+
+        //create a funky-unique filename in case of concurrent file access issues (multiple users trying to export at once)
+        long time = System.currentTimeMillis();
+        long threadId = Thread.currentThread().getId();
+        String fileName = time + "-" + threadId;
+
+        generatePDF(semesterAsMarkdown, fileName);
 
         JSONObject responseJson = new JSONObject();
+
+        try {
+            responseJson.put("exportPath","/exports/"+fileName+".pdf");
+        } catch (JSONException e) {
+            logger.error("JSONException occured");
+            e.printStackTrace();
+        }
 
         PrintWriter out = response.getWriter();
         ServletContext cntxt = this.getServletContext();
 
         logger.info("Responding with: " + responseJson.toString());
         out.println(responseJson.toString());
+    }
+
+    private String semesterListToMarkdownString(ArrayList<Semester> semesters) {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("# My Course Sequence\n\n");
+
+        int year = 0;
+        for (int i = 0; i < semesters.size(); i++) {
+            if (i % 3 == 0) {
+                year++;
+            }
+            Semester semester = semesters.get(i);
+            builder.append("### " + semester.getSeason() + " " + year + "\n\n");
+            if (semester.isWorkTerm()) {
+                builder.append("- Work Term\n");
+            } else {
+                for (Course course : semester.getCourses()) {
+                    if (course.isElective()) {
+                        builder.append("- " + course.getElectiveType() + " Elective\n");
+                    } else {
+                        builder.append("- " + course.getCode() + ", " + course.getName() + ", " + course.getCredits() + " Credits\n");
+                    }
+                }
+            }
+            builder.append("\n");
+        }
+        return builder.toString();
+    }
+
+    // generate a pdf file in EXPORTS_DIR folder with name {fileName}.pdf
+    private String generatePDF(String markdownString, String fileName) {
+
+        // First, we write the markdown string to a .md file
+        File outputFile = new File(EXPORTS_DIR + fileName + ".md");
+        try {
+            if(!outputFile.exists()){
+                outputFile.createNewFile();
+            }
+            PrintWriter out = new PrintWriter(outputFile);
+            out.println(markdownString);
+            out.close();
+        } catch (FileNotFoundException e) {
+            logger.error("File not found");
+            e.printStackTrace();
+        } catch (IOException e) {
+            logger.error("IO Exception while writing to markdown file");
+            e.printStackTrace();
+        }
+
+        //Second, we run pandoc on that .md file to generate a .pdf
+        runPandoc(fileName);
+
+        return fileName;
+    }
+
+    private void runPandoc(String fileName){
+
+        String filePath = EXPORTS_DIR + fileName;
+        String commandString = "pandoc " + filePath + ".md -o " + filePath + ".pdf";
+        logger.info("executing command: " + commandString);
+
+        try {
+            Process proc = Runtime.getRuntime().exec(commandString);
+            BufferedReader read = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+            try {
+                proc.waitFor();
+            } catch (InterruptedException e) {
+                logger.error("Interrupted Exception");
+                e.printStackTrace();
+            }
+            while (read.ready()) {
+                logger.warn("Pandoc output:" + read.readLine());
+            }
+        } catch (IOException e) {
+            logger.error("IO Exception while running pandoc");
+            e.printStackTrace();
+        }
     }
 
 }

--- a/src/main/webapp/exports/manway.txt
+++ b/src/main/webapp/exports/manway.txt
@@ -1,1 +1,11 @@
 manmanwei
+.
+.
+.
+.
+.
+.
+.
+.
+.
+For real though we need at least 1 file inside the exports folder otherwise the directory doesn't get created on the VM

--- a/src/main/webapp/exports/manway.txt
+++ b/src/main/webapp/exports/manway.txt
@@ -1,0 +1,1 @@
+manmanwei

--- a/src/main/webapp/js/script.js
+++ b/src/main/webapp/js/script.js
@@ -300,6 +300,7 @@ function fillCourseInfoBox(courseInfo){
 }
 
 function exportSequence(){
+    $("#exportWaiting").css("display","inline-block");
     generateSequenceObject( function(result){
         var oReq = new XMLHttpRequest();
         oReq.addEventListener("load", function(){
@@ -307,12 +308,31 @@ function exportSequence(){
             var response = JSON.parse(this.responseText);
             console.log("Server export response: " + this.responseText);
 
+            if(response.exportPath){
+                var downloadUrl = "http://138.197.6.26/courseplanner" + response.exportPath;
+                saveAs(downloadUrl, "MySequence.pdf");
+                $("#exportWaiting").css("display","none");
+            }
+
         });
         oReq.open("POST", "http://138.197.6.26/courseplanner/export");
         oReq.send(JSON.stringify({
             "semesterList": result
         }));
     });
+}
+
+function saveAs(uri, filename) {
+    var link = document.createElement('a');
+    if (typeof link.download === 'string') {
+        document.body.appendChild(link); // Firefox requires the link to be in the body
+        link.download = filename;
+        link.href = uri;
+        link.click();
+        document.body.removeChild(link); // remove the link when done
+    } else {
+        location.replace(uri);
+    }
 }
 
 

--- a/src/main/webapp/sequenceBuilder.html
+++ b/src/main/webapp/sequenceBuilder.html
@@ -5,6 +5,7 @@
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
 		<link rel="stylesheet" type="text/css" href="css/styles.css">
 		<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+		<link rel="stylesheet" href="lib/font-awesome/css/font-awesome.min.css">
 		<script type="text/javascript" src="js/script.js"></script>
 		<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 
@@ -21,7 +22,7 @@
 				<p class="error">Current sequence is valid</p>
 			</div>
 			<div class="export">
-				<button class="exportButton">EXPORT</button>
+				<button class="exportButton">EXPORT&nbsp;&nbsp;<i id="exportWaiting" class="fa fa-cog fa-spin fa-fw" style="display: none;"></i></button>
 			</div>
 		</div>
 		<div class="sequenceContainer">


### PR DESCRIPTION
### Here's how it works:

1. The client presses "Export" which sends a POST request to courseplanner/export with the same body that it would send for a sequence validation request (the sequence info inside a JSON object).

2. The server converts the JSON into markdown, writes the markdown to a file, then runs `pandoc` on the markdown to convert it into pdf. Then, it will respond back to the website with a JSON object which contains 1 member: "exportPath", which contains the relative path to the file with respect to the website's root directory.

3. Once the client receives the response, it will read the exportPath and build the full url to the file (looks something like http://138.197.6.26/courseplanner/exports/1234567890-123.pdf). At that point it simply dowloads the file at that URL by simulating a click on a link (stole the convenience function off Stack overflow to do this, see script.js:325).

### Issues:

- the `exports` directory gets two new files added to it every time you request an export, this could get a little out of hand as it gets filled up with lost of files so we need some way of keeping this folder clean. Note that this directory gets cleared every time you run deploy.sh - this is also an issue in itself. Maybe we can move the exports folder outside of the tomcat directory and run a simple apache on it so the files are still downloadable... idk

- Writer's block... there's definitely more issues/missing features

*Looks like I didn't have time to do the search auto-complete tonight.... lol gnight bros*