### PR TITLE
Course info sources update

### DIFF
--- a/webscraping/r/courseinfo-data-sources.txt
+++ b/webscraping/r/courseinfo-data-sources.txt
@@ -37,3 +37,144 @@ https://www.concordia.ca/academics/undergraduate/calendar/current/sec71/71-70.ht
 SOEN
 https://www.concordia.ca/academics/undergraduate/calendar/current/sec71/71-70.html#softeng
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(81)
+ADED
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-090.html#b31.090.2
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(27)
+AHSC
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-010.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+BIOL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-030.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+CHEM
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-050.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(11)
+CLAS
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
+MARA
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(23)
+MCHI
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(25)
+GERM
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(27)
+ITAL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(29)
+SPAN
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(31)
+LING
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(33)
+HEBR
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(35)
+MGRK
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(37)
+COMS
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-070.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
+ECON
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-080.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+EDUC
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-090.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+ENGL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-100.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(11)
+TESL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-090.html#b31.090.1
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
+ESL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-090.html#ESL_Courses
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(23)
+FRAN
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-110.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+CATA
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-120.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+GEOG
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-130.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+GEOL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-130.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(15)
+URBS
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-130.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
+HIST
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-160.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(11)
+INTE
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-170.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(24)
+JOUR
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-180.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+ACTU
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-200.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+MACF
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-200.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(15)
+MAST
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-200.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(17)
+MATH
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-200.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(19)
+STAT
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-200.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
+PHIL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-220.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(9)
+PHYS
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-230.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+POLI
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-240.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(23)
+PSYC
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-250.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(23)
+RELI
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-270.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(11)
+SOCI
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-310.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+ANTH
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-310.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(19)
+THEO
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-330.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(9)
+LBCL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-520.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(11)
+LOYC
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-525.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(11)
+IRST
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-530.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(9)
+SCPA
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-540.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(11)
+FPST
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-540.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(17)
+SCOL
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-550.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
+WSDB
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-560.html
+#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(14)

--- a/webscraping/r/courseinfo-data-sources.txt
+++ b/webscraping/r/courseinfo-data-sources.txt
@@ -73,9 +73,6 @@ http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.ht
 HEBR
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(35)
-MGRK
-http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
-#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(37)
 COMS
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-070.html
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
@@ -91,9 +88,6 @@ http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-100.ht
 TESL
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-090.html#b31.090.1
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
-ESL
-http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-090.html#ESL_Courses
-#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(23)
 FRAN
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-110.html
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)

--- a/webscraping/r/courseinfo-data-sources.txt
+++ b/webscraping/r/courseinfo-data-sources.txt
@@ -53,7 +53,7 @@ CLAS
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
 MARA
-http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31
+http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(23)
 MCHI
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-060.html

--- a/webscraping/r/scrape-course-data.r
+++ b/webscraping/r/scrape-course-data.r
@@ -15,6 +15,9 @@ urls          <- urls.and.css.selectors[seq(from = 2, to = length(urls.and.css.s
 css.selectors <- urls.and.css.selectors[seq(from = 3, to = length(urls.and.css.selectors), by = 3)]
 
 for(i in 1:num.scrapes) {
+    # print(i)
+    # print(program.name[i])
+
     htmlpage.string <- read_html(urls[i]) # get the raw html
     program.html.string <- htmlpage.string %>%
         html_node(css = css.selectors[i]) # extract desired DOM


### PR DESCRIPTION
I added 45 more course types from other faculties to scrape info for. MGRK and ESL are the only problematic instances.

Found the course descriptions [here](http://www.concordia.ca/academics/undergraduate/calendar/current/contents.html) while navigating the navbar with the title "Undergraduate Calendar 2017-2018"