### PR TITLE
delete and remake scraped json dir before scrape

### DIFF
--- a/webscraping/scrapeTheWeb.sh
+++ b/webscraping/scrapeTheWeb.sh
@@ -3,14 +3,16 @@
 # This is our script for running our webscraping activites. It it to be run in a cron script.
 # Example: 0 0 * * * sh /home/david/CoursePlanner/webscraping/scrapeTheWeb.sh
 
-pushd `dirname $0` > /dev/null
-webscrapedir=$(pwd)
+pushd `dirname $0` > /dev/null # this script is now in the directory of this file
+webscrapedir=$(pwd) # save this directory as $webscrapedir
 popd > /dev/null
 
 # run scraper for course sequences
 cd "$webscrapedir/node/course-seq-scraper"
 node scrapeAndValidate.js
 
+# delete and remake the directory to hold scraped course-info json files
+rm -r $webscrapedir/r/course-info-jsonfiles; mkdir $webscrapedir/r/course-info-jsonfiles
 # run scraper for course data
 cd "$webscrapedir/r"
 Rscript scrape-course-data.r

--- a/webscraping/scrapeTheWeb.sh
+++ b/webscraping/scrapeTheWeb.sh
@@ -3,8 +3,8 @@
 # This is our script for running our webscraping activites. It it to be run in a cron script.
 # Example: 0 0 * * * sh /home/david/CoursePlanner/webscraping/scrapeTheWeb.sh
 
-pushd `dirname $0` > /dev/null # this script is now in the directory of this file
-webscrapedir=$(pwd) # save this directory as $webscrapedir
+pushd `dirname $0` > /dev/null
+webscrapedir=$(pwd)
 popd > /dev/null
 
 # run scraper for course sequences


### PR DESCRIPTION
In `scrape-the-web.sh`, delete and remake the directory
`course-info-jsonfiles` before populating it with files containing
scraped json.

This prevents the scrape from failing in the case where the directory does not exist. However, it also deletes all the jsonfiles each time we scrape, which is not necessarily ideal.  Thoughts?

This PR resolves #31 