### PR TITLE
Added minTotalCredits

### DIFF
--- a/src/main/webapp/css/styles.css
+++ b/src/main/webapp/css/styles.css
@@ -287,6 +287,11 @@ p.mainHeader {
 	text-align: center;
 }
 
+p.subHeader {
+	font: italic small-caps normal 20px Arial, Helvetica, sans-serif;
+	text-align: center;
+}
+
 ::-webkit-input-placeholder { /* Chrome/Opera/Safari */
   font-family: Orbitron, Arial, Helvetica, sans-serif;
 }

--- a/src/main/webapp/js/script.js
+++ b/src/main/webapp/js/script.js
@@ -21,7 +21,8 @@ $(document).ready(function() {
 
 function loadSequence(){
     // clear whole page first
-    $(".sequenceContainer").html("<p class='mainHeader'>Concordia Engineering Sequence Builder</p>");
+    $(".sequenceContainer").html("<p class='mainHeader'>Concordia Engineering Sequence Builder</p>" +
+                                 "<p class='subHeader'></p>");
     workTermCount = 0;
 
     var savedSequence = JSON.parse(localStorage.getItem("savedSequence"));
@@ -93,6 +94,9 @@ function populatePage(courseSequenceObject){
     // clear all course containers first as we may call this more than once
     // (this will remove all draggable course rows)
     $(".courseContainer").empty();
+
+    // add in sub header
+    $(".subHeader").text("Selected program: " + localStorage.getItem("sequenceType") + ", minCredits: " + courseSequenceObject.minTotalCredits);
 
     for(var i = 0; i < courseSequenceObject.semesterList.length; i++){
         var $courseContainer = $(".sequenceContainer .term:nth-of-type(" + (i + 1) +") .courseContainer");

--- a/src/main/webapp/sequenceBuilder.html
+++ b/src/main/webapp/sequenceBuilder.html
@@ -31,8 +31,6 @@
 				<button class="exportButton" title="Export your sequence to PDF.">EXPORT&nbsp;&nbsp;<i id="exportWaiting" class="fa fa-cog fa-spin fa-fw" style="display: none;"></i></button>
 			</div>
 		</div>
-		<div class="sequenceContainer">
-			<p class="mainHeader">Concordia Engineering Sequence Builder</p>
-		</div>
+		<div class="sequenceContainer"></div>
 	</body>
 </html>

--- a/webscraping/node/course-seq-scraper/scraper.js
+++ b/webscraping/node/course-seq-scraper/scraper.js
@@ -14,6 +14,7 @@ function scrapeEncsSequenceUrl(url, outPath, plainFileName, shouldBeVerbose, onC
             var courseList = [];
             var currentSeason = "";
             var hasStartedScraping = false;
+            var minTotalCredits = $(".section.title .section-header").text().match(/\S*\d+\S*/)[0];
 
             $(".concordia-table.table-condensed tbody > tr").each(function(i, el){
                 var $row = $(this);
@@ -128,6 +129,7 @@ function scrapeEncsSequenceUrl(url, outPath, plainFileName, shouldBeVerbose, onC
 
             var sequenceObject = {
                 "sourceUrl": url,
+                "minTotalCredits" : minTotalCredits,
                 "semesterList" : semesterList
             };
 


### PR DESCRIPTION
I noticed that the reccomended sequence pages include the minimum needed credits for each program, so I took advantage of this. 

The sequence scraper now includes this in the data that it generates by adding a new property to the object: `minTotalCredits`. I also added a visual indicator in the frontend so you can see both the reccomended sequence that you chose on the splash page as well as the associated minimum credits.