### PR TITLE
Splash page update

### DIFF
--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -10,7 +10,7 @@ body {
     background-size: cover;
 }
 
-#Main {
+#main {
 	/*background-color: rgba(175,175,175,0.1);*/
 	padding: 4px 0px;
 }
@@ -21,7 +21,6 @@ body {
   position: relative;
   text-align: center;
   top: 0%;
-  width: 60%;
 }
 
 #box {
@@ -29,8 +28,8 @@ body {
   margin: 0 auto;
   position: relative;
   text-align: center;
-  top: 200px;
   width: 100%;
+  float: right;
 }
 
 #inputGroup select {
@@ -79,7 +78,7 @@ body {
 
 	background-color: rgba(175,175,175, 1);
 	cursor: pointer;
-
+  
 } 
 
 #checkbox:active {
@@ -110,13 +109,26 @@ body {
 
 #credits {
 
-    position: absolute;
-    right: 16px;
-    top: 16px;
-
     text-align: center;
     font-family: orbitron;
     font-size: 18px;
     font-weight: bold;
     letter-spacing: 0.8px;
+    float: right;
+    margin-right: 1%;
+    background-color: rgba(100, 100, 100, 0.7);
+
+}
+
+/* unvisited link */
+a:link {
+  color: #900C3F; /* concordia magenta */
+}
+
+a:active {
+  color: white;
+}
+
+a:hover {
+  color: orange;
 }

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -49,13 +49,10 @@ body {
 }
 
 #inputGroup select:hover {
-
 	background-color: rgba(175,175,175, 1);
-
 } 
 
 #inputGroup select:active {
-
 	border: 2px solid #000000;
 }
 
@@ -75,19 +72,16 @@ body {
 }
 
 #checkbox:hover {
-
 	background-color: rgba(175,175,175, 1);
 	cursor: pointer;
   
 } 
 
 #checkbox:active {
-
 	border: 2px solid #000000;
 }
 
 .btn {
-
 	color: #000033;
 	/*background color: rgba(175,175,175,0.8);*/
 	letter-spacing: 0.8px;
@@ -98,17 +92,13 @@ body {
 	margin-top: 97px;
 	height: 40px;
 	width: 100px;
-
 }
 
 .btn:hover {
-
 	cursor: pointer;
-
 }
 
 #credits {
-
     text-align: center;
     font-family: orbitron;
     font-size: 18px;
@@ -116,13 +106,11 @@ body {
     letter-spacing: 0.8px;
     float: right;
     margin-right: 1%;
-    background-color: rgba(100, 100, 100, 0.7);
-
 }
 
 /* unvisited link */
 a:link {
-  color: #900C3F; /* concordia magenta */
+  color: blue; /* concordia magenta */
 }
 
 a:active {

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 	<head>
-
 		<meta charset="utf-8">
 		<title> Concordia Engineering Sequence Builder </title>
 		<link rel="stylesheet" type="text/css" href="css/index.css">
@@ -12,48 +11,52 @@
 	</head>
 	<body> 
 
-		<div class="header">
-    		<div id="header-text">
-      			<h1 id="Main">Welcome to your custom Sequence builder</h1>
-				<div id = "box">
-					<div>
-						<div id="inputGroup">
-							<select id="SequenceType">
-								<option selected="true" value="NULL" disabled="disabled">Select an sequence type</option>
-							</select>
-							<!--<select id="Semester">-->
-								<!--<option selected="true" value="Select an entry Semester" disabled="disabled">Select an entry Semester</option>-->
-								<!--<option value="Fall">Fall</option>-->
-								<!--<option value="Winter">Winter</option>-->
-							<!--</select>-->
-							<!--<select id="Program">-->
-								<!--<option selected="true" value="Select a Program" disabled="disabled">Select a Program</option>-->
-								<!--<option value="Software Engineering">Software Engineering</option>-->
-								<!--<option value="Computer science">Computer science</option>-->
-							<!--</select>-->
-							<!--<div id="checkbox">-->
-								<!--<input type="checkbox" name="Co-op">Co-op Program?</input>-->
-							<!--</div>-->
-						</div>
-					</div>
-				  <button onclick="myFunction()" class="btn">Continue</button>
-				</div>
-    		</div>
-  		</div>
+	<div class="main-wrapper">
+		<div id="header-text">
+				<h1 id="main">Welcome to your custom Sequence builder</h1>
+		</div>
 		<div id="credits">
-			Built at <a href="http://www.conuhacks.io" target="_blank">ConUHacks 2</a> by:<br/>
-			David Huculak<br/>
-			Stuart Mashaal<br/>
-			Peter Granitski<br/>
-			Josh Abravanel<br/>
-			Mikel Shifrin<br/>
+			Built at <a href="http://www.conuhacks.io" target="_blank">ConUHacks 2</a> by:<br>
+			David Huculak<br>
+			Stuart Mashaal<br>
+			Peter Granitski<br>
+			Josh Abravanel<br>
+			Mikel Shifrin<br>
 
-			<a href="https://github.com/Davidster/MyWebsite" target="_blank">
+			<a href="https://github.com/stumash/CoursePlanner" target="_blank">
 				<div class="github label clickable">
 					<i class="fa fa-github"></i>
 					<br>View source on Github
 				</div>
 			</a>
 		</div>
+	</div>
+
+
+
+		<div id="box">
+			<div>
+				<div id="inputGroup">
+					<select id="SequenceType">
+						<option selected="true" value="NULL" disabled="disabled">Select an sequence type</option>
+					</select>
+					<!--<select id="Semester">-->
+						<!--<option selected="true" value="Select an entry Semester" disabled="disabled">Select an entry Semester</option>-->
+						<!--<option value="Fall">Fall</option>-->
+						<!--<option value="Winter">Winter</option>-->
+					<!--</select>-->
+					<!--<select id="Program">-->
+						<!--<option selected="true" value="Select a Program" disabled="disabled">Select a Program</option>-->
+						<!--<option value="Software Engineering">Software Engineering</option>-->
+						<!--<option value="Computer science">Computer science</option>-->
+					<!--</select>-->
+					<!--<div id="checkbox">-->
+						<!--<input type="checkbox" name="Co-op">Co-op Program?</input>-->
+					<!--</div>-->
+				</div>
+			</div>
+			<button onclick="myFunction()" class="btn">Continue</button>
+		</div>
+
 	</body>
 </html>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+	
 		<meta charset="utf-8">
 		<title> Concordia Engineering Sequence Builder </title>
 		<link rel="stylesheet" type="text/css" href="css/index.css">
@@ -11,29 +12,26 @@
 	</head>
 	<body> 
 
-	<div class="main-wrapper">
-		<div id="header-text">
-				<h1 id="main">Welcome to your custom Sequence builder</h1>
+		<div class="main-wrapper">
+			<div id="header-text">
+					<h1 id="main">Welcome to your custom Sequence builder</h1>
+			</div>
+			<div id="credits">
+				Built at <a href="http://www.conuhacks.io" target="_blank">ConUHacks 2</a> by:<br>
+				David Huculak<br>
+				Stuart Mashaal<br>
+				Peter Granitski<br>
+				Josh Abravanel<br>
+				Mikel Shifrin<br>
+
+				<a href="https://github.com/stumash/CoursePlanner" target="_blank">
+					<div class="github label clickable">
+						<i class="fa fa-github"></i>
+						<br>View source on Github
+					</div>
+				</a>
+			</div>
 		</div>
-		<div id="credits">
-			Built at <a href="http://www.conuhacks.io" target="_blank">ConUHacks 2</a> by:<br>
-			David Huculak<br>
-			Stuart Mashaal<br>
-			Peter Granitski<br>
-			Josh Abravanel<br>
-			Mikel Shifrin<br>
-
-			<a href="https://github.com/stumash/CoursePlanner" target="_blank">
-				<div class="github label clickable">
-					<i class="fa fa-github"></i>
-					<br>View source on Github
-				</div>
-			</a>
-		</div>
-	</div>
-
-
-
 		<div id="box">
 			<div>
 				<div id="inputGroup">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -6,6 +6,7 @@
 		<title> Concordia Engineering Sequence Builder </title>
 		<link rel="stylesheet" type="text/css" href="css/index.css">
 		<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+		<link rel="stylesheet" href="lib/font-awesome/css/font-awesome.min.css">
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 		<script src="js/main.js"></script>
 	</head>
@@ -46,6 +47,13 @@
 			Peter Granitski<br/>
 			Josh Abravanel<br/>
 			Mikel Shifrin<br/>
+
+			<a href="https://github.com/Davidster/MyWebsite" target="_blank">
+				<div class="github label clickable">
+					<i class="fa fa-github"></i>
+					<br>View source on Github
+				</div>
+			</a>
 		</div>
 	</body>
 </html>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -26,8 +26,7 @@
 
 				<a href="https://github.com/stumash/CoursePlanner" target="_blank">
 					<div class="github label clickable">
-						<i class="fa fa-github"></i>
-						<br>View source on Github
+						<i class="fa fa-github"></i><br>View source on Github
 					</div>
 				</a>
 			</div>

--- a/src/main/webapp/sequenceBuilder.html
+++ b/src/main/webapp/sequenceBuilder.html
@@ -7,11 +7,9 @@
 		<link rel="stylesheet" href="lib/font-awesome/css/font-awesome.min.css">
 		<link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
 		<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
-
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
 		<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 		<script type="text/javascript" src="js/script.js"></script>
-
 		<title>Concordia Engineering Sequence Builder</title>
 	</head>
 	<body>


### PR DESCRIPTION
In this branch I made the following changes to the splash page:
- Added a link to our github site as a clickable github logo icon
- Put credits underneath the main title, thus eliminating the overlapping of them
- Added a grey opaque background to the credits div to make it more readable with the contrast
- Messed around with the pseudo classes for the colors of links on the splash page

Check out the changes [here](http://138.197.6.26/courseplannerp/)