### PR TITLE
Sexified frontend code

### DIFF
--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -3,9 +3,7 @@ import React from "react";
 export class SemesterBox extends React.Component {
 
     renderCourseList(){
-        if(!this.props.semester){
-            return;
-        }
+
         let courseList = this.props.semester.courseList || [];
         let isWorkTerm = this.props.semester.isWorkTerm || "false";
 

--- a/src/main/webapp/babel-src/semesterList.js
+++ b/src/main/webapp/babel-src/semesterList.js
@@ -1,6 +1,5 @@
 import React from "react";
 import {SemesterBox} from "./semesterBox";
-import {fillMissingSemesters} from "./util";
 import {SEASON_NAMES} from "./util";
 
 /*
@@ -18,32 +17,16 @@ export class SemesterList extends React.Component {
 
         if(!this.props.courseSequenceObject.isLoading){
 
-            const semesterList = this.props.courseSequenceObject.semesterList;
+            const yearList = this.props.courseSequenceObject.yearList;
 
-            let filledSemesterList = fillMissingSemesters(semesterList);
-
-            let listContent = [];
-
-            for(let year = 1; year <= (Math.ceil(filledSemesterList.length/3)); year++){
-                SEASON_NAMES.forEach((season, seasonIndex) =>
-                    {
-                        let currentSemester = filledSemesterList[((year-1)*3)+seasonIndex] || {};
-                        if(currentSemester){
-                            listContent.push(
-                                <div className="semesterListItem col-xs-12" key={season + "" + year}>
-                                    <div className="semesterID text-center col-xs-8 col-xs-offset-2">{season + " " + year}</div>
-                                    <SemesterBox year={year} season={season} semester={currentSemester}/>
-                                </div>
-                            );
-                        } else {
-                            listContent.push(<td key={season}></td>);
-                        }
-                    }
-
-                );
-            }
-
-            return listContent;
+            return yearList.map((year, yearNumber) =>
+                {SEASON_NAMES.map((season) =>
+                    <div className="semesterListItem col-xs-12" key={season + "" + yearNumber}>
+                        <div className="semesterID text-center col-xs-8 col-xs-offset-2">{season + " " + yearNumber}</div>
+                        <SemesterBox year={yearNumber} season={season} semester={yearList[yearNumber][season]}/>
+                    </div>
+                )}
+            );
         }
     }
 

--- a/src/main/webapp/babel-src/semesterList.js
+++ b/src/main/webapp/babel-src/semesterList.js
@@ -19,13 +19,13 @@ export class SemesterList extends React.Component {
 
             const yearList = this.props.courseSequenceObject.yearList;
 
-            return yearList.map((year, yearNumber) =>
-                {SEASON_NAMES.map((season) =>
-                    <div className="semesterListItem col-xs-12" key={season + "" + yearNumber}>
-                        <div className="semesterID text-center col-xs-8 col-xs-offset-2">{season + " " + yearNumber}</div>
-                        <SemesterBox year={yearNumber} season={season} semester={yearList[yearNumber][season]}/>
+            return yearList.map((year, yearIndex) =>
+                SEASON_NAMES.map((season) =>
+                    <div className="semesterListItem col-xs-12" key={season + "" + yearIndex}>
+                        <div className="semesterID text-center col-xs-8 col-xs-offset-2">{season + " " + (yearIndex + 1)}</div>
+                        <SemesterBox semester={yearList[yearIndex][season]}/>
                     </div>
-                )}
+                )
             );
         }
     }

--- a/src/main/webapp/babel-src/semesterTable.js
+++ b/src/main/webapp/babel-src/semesterTable.js
@@ -20,12 +20,12 @@ export class SemesterTable extends React.Component {
 
             const yearList = this.props.courseSequenceObject.yearList;
 
-            return yearList.map((year, yearNumber) =>
-                <tr key={yearNumber}>
-                    <td className="text-center">{yearNumber}</td>
+            return yearList.map((year, yearIndex) =>
+                <tr key={yearIndex}>
+                    <td className="text-center">{(yearIndex + 1)}</td>
                     {SEASON_NAMES.map((season) =>
                         <td key={season}>
-                            <SemesterBox year={yearNumber} season={season} semester={yearList[yearNumber][season]}/>
+                            <SemesterBox semester={yearList[yearIndex][season]}/>
                         </td>
                     )}
                 </tr>

--- a/src/main/webapp/babel-src/semesterTable.js
+++ b/src/main/webapp/babel-src/semesterTable.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {SemesterBox} from "./semesterBox";
-import {fillMissingSemesters} from "./util";
 import {SEASON_NAMES} from "./util";
+import {SEASON_NAMES_PRETTY} from "./util";
 
 /*
  *  Table which contains all courses of current sequence
@@ -18,35 +18,18 @@ export class SemesterTable extends React.Component {
 
         if(!this.props.courseSequenceObject.isLoading){
 
-            const semesterList = this.props.courseSequenceObject.semesterList;
+            const yearList = this.props.courseSequenceObject.yearList;
 
-            let filledSemesterList = fillMissingSemesters(semesterList);
-            let tableContent = [];
-
-            for(let year = 1; year <= (Math.ceil(filledSemesterList.length/3)); year++){
-                tableContent.push(
-                    <tr key={year}>
-                        <td className="text-center">{year}</td>
-                        {SEASON_NAMES.map((season, seasonIndex) =>
-                            {
-                                let currentSemester = filledSemesterList[((year-1)*3)+seasonIndex] || {};
-                                if(currentSemester){
-                                    return (
-                                        <td key={season}>
-                                            <SemesterBox year={year} season={season} semester={currentSemester}/>
-                                        </td>
-                                    );
-                                } else {
-                                    return (<td key={season}></td>);
-                                }
-                            }
-
-                        )}
-                    </tr>
-                );
-            }
-
-            return tableContent;
+            return yearList.map((year, yearNumber) =>
+                <tr key={yearNumber}>
+                    <td className="text-center">{yearNumber}</td>
+                    {SEASON_NAMES.map((season) =>
+                        <td key={season}>
+                            <SemesterBox year={yearNumber} season={season} semester={yearList[yearNumber][season]}/>
+                        </td>
+                    )}
+                </tr>
+            );
         }
     }
 
@@ -54,7 +37,7 @@ export class SemesterTable extends React.Component {
         return (
             <tr>
                 <th className="text-center">Year</th>
-                {SEASON_NAMES.map((season) =>
+                {SEASON_NAMES_PRETTY.map((season) =>
                     <th className="text-center" key={season}>{season}</th>
                 )}
             </tr>

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -5,23 +5,6 @@
  *
  */
 
-export const SEASON_NAMES = ["Fall", "Winter", "Summer"];
+export const SEASON_NAMES_PRETTY = ["Fall", "Winter", "Summer"];
+export const SEASON_NAMES = SEASON_NAMES_PRETTY.map((season) => season.toLowerCase());
 export const DEFAULT_PROGRAM = "SOEN-General-Coop";
-
-// Take an array of semester objects and add in any missing semesters - this functionality will be rendered useless once we include years in the sequence JSON spec
-export function fillMissingSemesters(semesterList){
-    for(let i = 0; i < semesterList.length; i++){
-
-        let expectedSeason = SEASON_NAMES[i%3].toLowerCase();
-
-        if(!(semesterList[i].season === expectedSeason)){
-            semesterList.splice(i, 0, {
-                "courseList" : [],
-                "isWorkTerm" : "false",
-                "season" : expectedSeason
-            });
-        }
-
-    }
-    return semesterList;
-}

--- a/webscraping/node/course-seq-scraper/storer.js
+++ b/webscraping/node/course-seq-scraper/storer.js
@@ -51,7 +51,7 @@ var storeAllCourses = (function (){
                         if (numVerified == files.length) {
                             db.close();
                             if(foundIssue){
-                                //sendIssueEmail();
+                                sendIssueEmail();
                             }
                         }
                     });
@@ -205,10 +205,9 @@ function sendIssueEmail(){
         }
     });
 
-    //  petergranitski@gmail.com , stumash1@gmail.com
     var mailOptions = {
         from: '"Course Planner Debug" <concordiacourseplanner@gmail.com>', // sender address
-        to: 'davidhuculak5@gmail.com', // list of receivers
+        to: 'davidhuculak5@gmail.com, petergranitski@gmail.com , stumash1@gmail.com', // list of receivers
         subject: 'Course Planner has encountered an issue', // Subject line
         html: message // html body
     };


### PR DESCRIPTION
resolves #54 

## Summary

As per the first commit message:

1. Replaced semesterList with yearList in sequence json - each year is guaranteed to contain all 3 seasons, otherwise the file is not written to the DB
2. Updated sequence traversal in SequenceProvider.java - also made this code a lil more readable
3. Updated sequence traversal in frontend - some ugly code has been swept under the rug

The frontend code is much easier to understand now. The only component that's still a tiny bit messy is `SemesterBox` from `babel-src/semesterBox.js` due to OR-lists

## BTW

This change to the json spec of sequences completely breaks our old frontend. RIP 💀 