### PR TITLE
fixes to deploy.sh and add deployScraper.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -65,7 +65,7 @@ mvnCommand="mvn clean install"
 echo "building backend... (maven)"
 if eval $mvnCommand $verbose
 then
-    echo "backend build succssful. Transferring war file to VM"
+    echo "backend build successful"
 else
     echo "backend build failed"
     echo "deploy.sh failed"

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,53 +2,68 @@
 
 # This is the deploy script for the CoursePlanner webapp. To run it you will need to have maven installed and have permissions to scp the war file to the remote VM.
 
-if [ $# -gt 0 ] # need one arg
+# parse arguments and handle bad arguments
+if [ "$#" == "1" ]
 then 
     if [ "${1}" == "prod" ]
     then
         devname=""
+        prod=true
+        echo "deploy chosen: production"
     else
+        echo "deploy chosen: $1 development"
         devname="${1:0:1}"
+        prod=false
     fi
 else
-    echo "deploy.sh takes one arg, the name of the dev, for deploying dev-specific .war files." 1>&2
+    echo "deploy.sh failed"
+    echo "deploy.sh takes one argument: the name of the dev or \"prod\""
     exit 1
 fi
+
+echo ""
 
 # run frontend build tools
-echo "Building frontend..." &&
-if [ "${2}" == "x" ]
+echo "building frontend..."
+if $prod
 then
     # build for production (no react dev tools, optimized performance)
-    npm run build-prod
+    npmCommand="npm run build-prod"
 else
     # build for development (with react dev tools, bad performance)
-    npm run build-dev
-fi &&
-
-# compile backend sources and package frontend assets
-echo "Building backend..." &&
-mvn clean install -q &&
-projectBuildSuccessful=true
-
-if ! $projectBuildSuccessful
+    npmCommand="npm run build-dev"
+fi
+if $npmCommand # run the npm command and react to exit code
 then
-    echo "Project build failed" 1>&2
+    echo "frontend build successful"
+else
+    echo "frontend build failed"
     exit 1
 fi
-echo "Project build complete. Transferring war file to VM"
+
+echo ""
+
+# compile backend sources and package frontend assets
+echo "building backend..."
+if mvn clean install
+then
+    echo "backend build succssful. Transferring war file to VM"
+else
+    echo "backend build failed"
+    exit 1
+fi
+
+echo ""
 
 # transfer the built project onto the VM
 # this will trigger Tomcat to reload the site content
-scp "target/courseplanner.war" david@138.197.6.26:/opt/tomcat/webapps/"courseplanner${devname}.war" &&
-deploymentSuccessful=true
-
-# if ends with error code 0 (success) then print deployment complete, else deployment failed
-if $deploymentSuccessful
+deployToServerCommand="scp ./target/courseplanner.war david@138.197.6.26:/opt/tomcat/webapps/courseplanner${devname}.war"
+echo "copying .war file to server..."
+if $deployToServerCommand # run the deployment command and react to exit code
 then
-    echo -e "\nDeployed courseplanner${devname}.war successfully at: $(date)"
+    echo "copying courseplanner${devname}.war to server successful at: $(date)"
 else
-    echo -e "\nFailed to scp courseplanner${devname}.war at: $(date)"
+    echo "copying courseplanner${devname}.war to server failed at: $(date)"
     exit 1
 fi
 

--- a/deployScraper.sh
+++ b/deployScraper.sh
@@ -1,0 +1,1 @@
+rsync -rav webscraping david@138.197.6.26:/opt/cp-webscraping


### PR DESCRIPTION
### new usage of `deploy.sh`:
1st arg (required): either
* '`prod`' to deploy to production .war file using production version of React, or
* '`<devname>`' (where `<devname>` should be replaced with the dev's name) to deploy to the dev's .war file using the development version of React

2nd arg (optional):
* '`--verbose`' to see all `npm` and `maven` output.  Omit this arg to silence both `npm` and `maven`

So, an example usage would be `./deploy.sh stu --verbose`.  Another example: `./deploy.sh prod`

### add `deployScraper.sh`
I have added the file `deployScraper.sh` which can be used to copy over your current version of the `webscraping` directory to one the used on the server, which it keeps at `/opt/cp-webscraping`. 

`deployScraper.sh` contains only one line of code, a call to `rsync`.

this PR resolves #60 and resolves #51.