### PR TITLE
Used maven profiles to configure backend `buildType`

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -62,8 +62,14 @@ echo ""
 
 # compile backend sources and package frontend assets
 mvnCommand="mvn clean install"
+if $prod
+then
+    mvnProfile="-P prod"
+else
+    mvnProfile="-P dev"
+fi
 echo "building backend... (maven)"
-if eval $mvnCommand $verbose
+if eval $mvnCommand $mvnProfile $verbose
 then
     echo "backend build successful"
 else

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,18 @@
     <artifactId>course-planner</artifactId>
     <version>1.0.0</version>
     <packaging>war</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <build>
         <finalName>courseplanner</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
 
             <!-- Java compiler -->
@@ -23,28 +32,26 @@
                 <version>2.2</version>
             </plugin>
 
-            <!-- Javascript linter -->
-            <plugin>
-                <groupId>com.cj.jshintmojo</groupId>
-                <artifactId>jshint-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>lint</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <directories>
-                        <directory>src/main/webapp/js</directory>
-                    </directories>
-                    <failOnError>true</failOnError>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <buildType>dev</buildType>
+            </properties>
+        </profile>
+        <profile>
+            <id>prod</id>
+            <properties>
+                <buildType>prod</buildType>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
 

--- a/src/main/java/DBServlet.java
+++ b/src/main/java/DBServlet.java
@@ -15,8 +15,13 @@ public abstract class DBServlet extends CPServlet {
 
         // set up references to mongo collections
         MongoClient mongoClient = new MongoClient(new MongoClientURI(appProperties.getProperty("mongoUrl")));
-        MongoDatabase db = mongoClient.getDatabase(appProperties.getProperty("dbName"));
+        MongoDatabase db = mongoClient.getDatabase(getDbName());
         courseData = db.getCollection(appProperties.getProperty("courseDataCollectionName"));
         courseSequences = db.getCollection(appProperties.getProperty("courseSequenceCollectionName"));
     }
+
+    public String getDbName(){
+        return appProperties.getProperty("buildType").equals("prod") ? appProperties.getProperty("dbNameProd") : appProperties.getProperty("dbNameDev");
+    }
+
 }

--- a/src/main/resources/courseplanner.properties
+++ b/src/main/resources/courseplanner.properties
@@ -1,5 +1,9 @@
-dbName = courseplannerdb-dev
+buildType = ${buildType}
+
+dbNameDev = courseplannerdb-dev
+dbNameProd = courseplannerdb
 mongoUrl = mongodb://138.197.6.26:27017
 courseDataCollectionName = courseData
 courseSequenceCollectionName = courseSequences
+
 exportsDirectory = exports


### PR DESCRIPTION
This pull request concludes the requirements described at the bottom of #61. 
## Summary
As per title, there is now a property inside `courseplanner.properties` called `buildType` which gets set to a value only a build time via [resource filtering](https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html) and [profiles](http://maven.apache.org/guides/introduction/introduction-to-profiles.html). Its value will be set depending on which profile is defined for the maven build, default is `dev`.
- To build backend for dev: 
`mvn clean install` or more explicitly `mvn clean install -P dev`
- To build backend for prod:
`mvn clean install -P prod`
#### I have included the necessary clause in `deploy.sh` to ensure that `buildType` is set to the correct value.
## Less importantly
I've removed javascript linting from the maven build process since Babel already validates our js code.
