### PR TITLE
Add export to new frontend

### DIFF
--- a/src/main/java/CPServlet.java
+++ b/src/main/java/CPServlet.java
@@ -38,28 +38,46 @@ public abstract class CPServlet extends HttpServlet {
         }
     }
 
-    Object grabPropertyFromRequest(String key, HttpServletRequest request) throws IOException {
+    JSONObject getRequestJson(HttpServletRequest request) throws IOException{
         StringBuffer jb = new StringBuffer();
         String line;
         Object propertyValue = null;
         JSONObject requestJson;
-        ArrayList<Semester> semesters = new ArrayList<Semester>();
         try {
             BufferedReader reader = request.getReader();
             while ((line = reader.readLine()) != null) {
                 jb.append(line);
             }
+            reader.close();
         } catch (Exception e) {
             e.printStackTrace();
             throw new IOException("Error reading from request string");
         }
         try {
+            logger.info("raw request String:");
+            logger.info(jb.toString());
+            logger.info("end raw request String");
             requestJson =  new JSONObject(jb.toString());
-            propertyValue = requestJson.get(key);
         } catch (JSONException e) {
             e.printStackTrace();
             throw new IOException("Error parsing JSON request string : " + jb.toString());
         }
+        return requestJson;
+    }
+
+    // This function can only be called once per request. It should be replaced by above method getRequestJson
+    Object grabPropertyFromRequest(String key, HttpServletRequest request) throws IOException {
+
+        Object propertyValue = null;
+        JSONObject requestJson = getRequestJson(request);
+
+        try {
+            propertyValue = requestJson.get(key);
+        } catch (JSONException e) {
+            e.printStackTrace();
+            throw new IOException("Error grabbing JSON property from request : " + requestJson.toString());
+        }
+
         return  propertyValue;
     }
 

--- a/src/main/java/SequenceExporter.java
+++ b/src/main/java/SequenceExporter.java
@@ -58,7 +58,7 @@ public class SequenceExporter extends CPServlet {
 
         StringBuilder builder = new StringBuilder();
 
-        builder.append("# My Course Sequence\n\n");
+        builder.append("# My Course Sequence\r\n\r\n");
 
         for (int yearIndex = 0; yearIndex < yearList.length(); yearIndex++) {
 
@@ -74,10 +74,10 @@ public class SequenceExporter extends CPServlet {
 
                 String prettySeason = ((season.charAt(0) + "").toUpperCase()) + season.substring(1);
 
-                builder.append("### " + prettySeason + " " + (yearIndex + 1) + ((isWorkTerm) ? " (Work Term)" : "") + "\n\n");
+                builder.append("### " + prettySeason + " " + (yearIndex + 1) + ((isWorkTerm) ? " (Work Term)" : "") + "\r\n\r\n");
 
                 if (courseList.length() == 0) {
-                    builder.append("- No Courses\n");
+                    builder.append("- No Courses\r\n");
                 }
 
                 // loop through course list and fill missing info for each course
@@ -106,7 +106,7 @@ public class SequenceExporter extends CPServlet {
                         logger.warn("Found unusual value inside course sequence. Expected a course object but found: " + entry.toString());
                     }
                 }
-                builder.append("\n");
+                builder.append("\r\n");
             }
         }
         return builder.toString();
@@ -114,9 +114,9 @@ public class SequenceExporter extends CPServlet {
 
     private String courseObjectToString(JSONObject course) throws JSONException{
         if(course.getBoolean("isElective")){
-            return ("- " + course.getString("electiveType") + " Elective\n");
+            return ("- " + course.getString("electiveType") + " Elective\r\n");
         } else {
-            return ("- " + course.getString("code") + ", " + course.getString("name") + ", " + course.getString("credits") + " Credits\n");
+            return ("- " + course.getString("code") + ", " + course.getString("name") + ", " + course.getString("credits") + " Credits\r\n");
         }
     }
 

--- a/src/main/webapp/babel-src/ioPanel.js
+++ b/src/main/webapp/babel-src/ioPanel.js
@@ -13,7 +13,10 @@ import {UI_STRINGS} from "./util";
  *
  *  courseInfo - json object containing the info of a course - directly pulled from DB
  *
+ *  loadingExport - boolean which tells us if were currently waiting for an export to finish
+ *
  *  onChangeChosenProgram - see MainPage.updateChosenProgram
+ *  exportSequence - see MainPage.exportSequence
  *
  */
 export class IOPanel extends React.Component {
@@ -88,20 +91,12 @@ export class IOPanel extends React.Component {
                     </button>
                     <ul className="dropdown-menu">
                         {EXPORT_TYPES.map((exportType) =>
-                            <li key={exportType}><a onClick={() => this.exportSequence(exportType)}>to {exportType}</a></li>
+                            <li key={exportType}><a onClick={() => this.props.exportSequence(exportType)}>to {exportType}</a></li>
                         )}
                     </ul>
+                    {this.props.loadingExport && <span className="smallLoadingSpinner glyphicon glyphicon-refresh glyphicon-spin"></span>}
                 </div>
             </div>
         );
     }
-
-    /*
-    *  Backend API calls:
-    */
-
-    exportSequence(exportType){
-        console.log("Should export to " + exportType);
-    }
-
 }

--- a/src/main/webapp/babel-src/ioPanel.js
+++ b/src/main/webapp/babel-src/ioPanel.js
@@ -44,7 +44,7 @@ export class IOPanel extends React.Component {
         } else {
             return (
                 <select className="form-control" onChange={this.handleSequenceSelection} disabled="disabled">
-                    <option>{UI_STRINGS.PROGRAM_LIST_LOADING}</option>
+                    <option>{UI_STRINGS.LIST_LOADING}</option>
                 </select>
             );
         }

--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -100,7 +100,7 @@ export class SemesterBox extends React.Component {
         });
 
         return (selectedCourse) ? this.renderCourse(selectedCourse, this.handleCourseSelection) :
-                                  <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP}>{UI_STRINGS.ORLIST_NONE_SELECTED}</div>;
+                                  <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP}>{UI_STRINGS.LIST_NONE_SELECTED}</div>;
     }
 
     renderCourse(courseObj, clickHandler){

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -26,10 +26,10 @@ export const UI_STRINGS = {
 
     "EXPORT_BTN_TEXT": "Export",
 
-    "PROGRAM_LIST_LOADING": "Loading...",
-
     "ORLIST_CHOICE_TOOLTIP": "Choose course from list of options",
-    "ORLIST_NONE_SELECTED": "None Selected"
+
+    "LIST_LOADING": "Loading...",
+    "LIST_NONE_SELECTED": "None Selected"
 
 };
 

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -8,7 +8,7 @@
 export const SEASON_NAMES_PRETTY = ["Fall", "Winter", "Summer"];
 export const SEASON_NAMES = SEASON_NAMES_PRETTY.map((season) => season.toLowerCase());
 export const DEFAULT_PROGRAM = "SOEN-General-Coop";
-export const EXPORT_TYPES = ["PDF", "CSV"];
+export const EXPORT_TYPES = ["PDF", "MD", "TXT"];
 
 // All hardcoded pieces of text which are directly displayed to the user
 export const UI_STRINGS = {
@@ -32,3 +32,18 @@ export const UI_STRINGS = {
     "ORLIST_NONE_SELECTED": "None Selected"
 
 };
+
+// convenience function that allows you to save the file contained at location uri to disk of client machine
+// currently used for downloading exported PDF file
+export function saveAs(uri, filename) {
+    var link = document.createElement('a');
+    if (typeof link.download === 'string') {
+        document.body.appendChild(link); // Firefox requires the link to be in the body
+        link.download = filename;
+        link.href = uri;
+        link.click();
+        document.body.removeChild(link); // remove the link when done
+    } else {
+        location.replace(uri);
+    }
+}

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -120,7 +120,7 @@
 
 .smallLoadingSpinner {
     font-size: 22px;
-    padding: 8px;
+    padding: 4px 12px;
 }
 
 .bigLoadingSpinner {


### PR DESCRIPTION
### Please *merge* #70 before reviewing this PR.
This PR is related to issue #45.
# Summary
Nothing fancy here. 
#### Updated export function in the backend to support our recent changes (#57) to our sequence JSON spec
- I moved away from our our past decision to parse the JSON request data into [POJO](http://lmgtfy.com/?q=what+is+a+pojo%3F)s (example [here](https://github.com/stumash/CoursePlanner/blob/dc896f37e4c1a84eaf6e2667e900c2bae673c8cf/src/main/java/Semester.java)). Simply used our `org.json` library instead.
#### Added a button drop down in the `IOPanel` which lets you export to `.pdf`, `.md`, or `.txt`. 
- It was super easy to support the second two options since our servlet was already creating a `.md` file prior to converting it to `.pdf` via `pandoc`. 
- Simply changed the extension of the final downloaded file for the `.txt` option.
#### On the topic of orLists
- If you don't select an option for any of the `orLists`, *no course will be put into the exported file for that entry*
- Obviously in the future we will want to warn the user not to export their sequence if it contains issues. Issues could be an *unsatisfied pre/corequisite*, *not enough credits taken*, or as I just mentioned an *unspecified orList option* @PeterGhimself 
## Test
Once again, test on `j` in case I'm in the middle of testing stuff on `d`: http://138.197.6.26/courseplannerj/