### PR TITLE
Added work term checkbox

### DIFF
--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -29,6 +29,7 @@ export class MainPage extends React.Component {
         this.updateChosenProgram = this.updateChosenProgram.bind(this);
         this.loadCourseInfo = this.loadCourseInfo.bind(this);
         this.setOrListCourseSelected = this.setOrListCourseSelected.bind(this);
+        this.toggleWorkTerm = this.toggleWorkTerm.bind(this);
         this.exportSequence = this.exportSequence.bind(this);
     }
 
@@ -80,6 +81,28 @@ export class MainPage extends React.Component {
         });
     }
 
+    /*
+     *  function to call in the event that the user toggles whether a semester is a work term or not
+     *      param yearIndex - index of the year of the semester
+     *      param season - the season of the semester
+     */
+    toggleWorkTerm(yearIndex, season){
+        this.setState((prevState) => {
+
+            // updated isWorkTerm property of semester in question
+            let isWorkTerm = prevState.courseSequenceObject.yearList[yearIndex][season].isWorkTerm;
+            prevState.courseSequenceObject.yearList[yearIndex][season].isWorkTerm = (isWorkTerm === "true") ? "false" : "true";
+
+            // save change to local storage
+            localStorage.setItem("savedSequence", JSON.stringify(prevState.courseSequenceObject));
+
+            // set new state based on changes
+            return {
+                "courseSequenceObject": prevState.courseSequenceObject
+            };
+        });
+    }
+
     render() {
         return (
             <div className="row">
@@ -95,12 +118,14 @@ export class MainPage extends React.Component {
                 <div className="col-sm-9 hidden-xs">
                     <SemesterTable courseSequenceObject={this.state.courseSequenceObject}
                                    onSelectCourse={this.loadCourseInfo}
-                                   onOrListSelection={this.setOrListCourseSelected}/>
+                                   onOrListSelection={this.setOrListCourseSelected}
+                                   onToggleWorkTerm={this.toggleWorkTerm}/>
                 </div>
                 <div className="col-xs-12 visible-xs">
                     <SemesterList courseSequenceObject={this.state.courseSequenceObject}
                                   onSelectCourse={this.loadCourseInfo}
-                                  onOrListSelection={this.setOrListCourseSelected}/>
+                                  onOrListSelection={this.setOrListCourseSelected}
+                                  onToggleWorkTerm={this.toggleWorkTerm}/>
                 </div>
             </div>
         );

--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -14,6 +14,7 @@ import {UI_STRINGS} from "./util";
  *
  *  onSelectCourse - see MainPage.loadCourseInfo
  *  onOrListSelection - see MainPage.setOrListCourseSelected
+ *  onToggleWorkTerm - see MainPage.toggleWorkTerm
  *
  */
 export class SemesterBox extends React.Component {
@@ -24,6 +25,7 @@ export class SemesterBox extends React.Component {
         // functions that are passed as callbacks need to be bound to current class - see https://facebook.github.io/react/docs/handling-events.html
         this.handleCourseSelection = this.handleCourseSelection.bind(this);
         this.handleOrListSelection = this.handleOrListSelection.bind(this);
+        this.handleWorkTermToggle = this.handleWorkTermToggle.bind(this);
     }
 
     handleCourseSelection(event){
@@ -34,14 +36,13 @@ export class SemesterBox extends React.Component {
         this.props.onOrListSelection(coursePosition);
     }
 
+    handleWorkTermToggle(){
+        this.props.onToggleWorkTerm(this.props.yearIndex, this.props.season);
+    }
+
     renderCourseList(){
 
         let courseList = this.props.semester.courseList || [];
-        let isWorkTerm = this.props.semester.isWorkTerm || "false";
-
-        if(isWorkTerm !== "false") {
-            return <div className="workTermIndicator text-center">{UI_STRINGS.WORK_TERM}</div>;
-        }
 
         if(courseList.length === 0) {
             return <div className="noCoursesIndicator text-center">{UI_STRINGS.NO_COURSES}</div>;
@@ -116,10 +117,22 @@ export class SemesterBox extends React.Component {
         );
     }
 
+    renderCheckBox(){
+        return <input type="checkbox"
+                      title={UI_STRINGS.IS_WORK_TERM}
+                      value="isWorkTerm"
+                      onChange={this.handleWorkTermToggle}
+                      defaultChecked={(this.props.semester.isWorkTerm === "true")}/>;
+
+    }
+
     render() {
         return (
-            <div className={"semesterBox"}>
+            <div className="semesterBox">
                 <div className="row">
+                    <div className="isWorkTerm col-xs-12">
+                        {this.renderCheckBox()}
+                    </div>
                     <div className="courseList col-xs-10 col-xs-offset-1">
                         {this.renderCourseList()}
                     </div>

--- a/src/main/webapp/babel-src/semesterList.js
+++ b/src/main/webapp/babel-src/semesterList.js
@@ -13,6 +13,7 @@ import {SEASON_NAMES_PRETTY} from "./util";
  *
  *  onSelectCourse - see MainPage.loadCourseInfo
  *  onOrListSelection - see MainPage.setOrListCourseSelected
+ *  onToggleWorkTerm - see MainPage.toggleWorkTerm
  *
  */
 export class SemesterList extends React.Component {
@@ -33,7 +34,8 @@ export class SemesterList extends React.Component {
                                  season={season}
                                  semester={yearList[yearIndex][season]}
                                  onSelectCourse={this.props.onSelectCourse}
-                                 onOrListSelection={this.props.onOrListSelection}/>
+                                 onOrListSelection={this.props.onOrListSelection}
+                                 onToggleWorkTerm={this.props.onToggleWorkTerm}/>
                 </div>
             )
         );

--- a/src/main/webapp/babel-src/semesterTable.js
+++ b/src/main/webapp/babel-src/semesterTable.js
@@ -13,6 +13,7 @@ import {SEASON_NAMES_PRETTY} from "./util";
  *
  *  onSelectCourse - see MainPage.loadCourseInfo
  *  onOrListSelection - see MainPage.setOrListCourseSelected
+ *  onToggleWorkTerm - see MainPage.toggleWorkTerm
  *
 */
 export class SemesterTable extends React.Component {
@@ -34,7 +35,8 @@ export class SemesterTable extends React.Component {
                                      season={season}
                                      semester={yearList[yearIndex][season]}
                                      onSelectCourse={this.props.onSelectCourse}
-                                     onOrListSelection={this.props.onOrListSelection}/>
+                                     onOrListSelection={this.props.onOrListSelection}
+                                     onToggleWorkTerm={this.props.onToggleWorkTerm}/>
                     </td>
                 )}
             </tr>

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -16,6 +16,7 @@ export const UI_STRINGS = {
     "SITE_NAME": "Conu Course Planner",
 
     "WORK_TERM": "Work Term",
+    "IS_WORK_TERM": " is work term?",
     "NO_COURSES": "No Courses",
 
     "COURSE_INFO_HEADER": "Course Info",

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -43,6 +43,12 @@
 
 /* Styling for SemesterBox */
 
+.semesterBox input {
+    margin-left: 4px;
+    height: 16px;
+    width: 16px;
+}
+
 .semesterItem {
     width: 160px;
     margin: 6px auto;


### PR DESCRIPTION
resolves #79 
## Summary
As per description of issue #79, I've added a checkbox that shows up in the top-left corner of each semester and reads "is work term?" when you hover over it. I added the necessary event listeners to make it so that the `courseSequenceObject` is updated according to the values in the checkboxes and vice versa.
## Test if you feel like it
`courseplannerj` is currently holding changes from another PR so test on `courseplannerd`. Make some semesters into work terms, refresh page, export to make sure work terms are still present, etc etc etc.