### PR TITLE
Add ELEC and COEN sequences

### DIFF
--- a/webscraping/node/course-seq/elecCoenHeadings.json
+++ b/webscraping/node/course-seq/elecCoenHeadings.json
@@ -1,0 +1,89 @@
+{
+    "url": "http://users.encs.concordia.ca/~eceweb/docs/ECE_CourseSequence_2016-2017.htm",
+    "headings": [
+        {
+            "id": "ELEC-NoOption-Sept",
+            "heading": "ELEC Regular Program"
+        },
+        {
+            "id": "ELEC-Tele-Sept",
+            "heading": "Telecommunications Option"
+        },
+        {
+            "id": "ELEC-Electronics-Sept",
+            "heading": "Electronics/VLSI Option"
+        },
+        {
+            "id": "ELEC-Avionics-Sept",
+            "heading": "Avionics and Control Systems"
+        },
+        {
+            "id": "ELEC-Power-Sept",
+            "heading": "Power and Renewable Energy"
+        },
+        {
+            "id": "ELEC-NoOption-Coop",
+            "heading": "ELEC Co-op Program"
+        },
+        {
+            "id": "ELEC-Tele-Coop",
+            "heading": "Telecommunications Option"
+        },
+        {
+            "id": "ELEC-Electronics-Coop",
+            "heading": "Electronics/VLSI Option"
+        },
+        {
+            "id": "ELEC-Avionics-Coop",
+            "heading": "Avionics and Control Systems"
+        },
+        {
+            "id": "ELEC-Power-Coop",
+            "heading": "Power and Renewable Energy"
+        },
+        {
+            "id": "ELEC-NoOption-Jan",
+            "heading": "ELEC Regular Program"
+        },
+        {
+            "id": "ELEC-Tele-Jan",
+            "heading": "Telecommunications Option"
+        },
+        {
+            "id": "ELEC-Electronics-Jan",
+            "heading": "Electronics/VLSI Option"
+        },
+        {
+            "id": "ELEC-Avionics-Jan",
+            "heading": "Avionics and Control Systems"
+        },
+        {
+            "id": "ELEC-Power-Jan",
+            "heading": "Power and Renewable Energy"
+        },
+        {
+            "id": "COEN-NoOption-Sept",
+            "heading": "COEN Regular Program"
+        },
+        {
+            "id": "COEN-Avionics-Sept",
+            "heading": "Avionics and Embedded Systems"
+        },
+        {
+            "id": "COEN-NoOption-Coop",
+            "heading": "COEN Co-op Program"
+        },
+        {
+            "id": "COEN-Avionics-Coop",
+            "heading": "Avionics and Embedded Systems"
+        },
+        {
+            "id": "COEN-NoOption-Jan",
+            "heading": "COEN Regular Program"
+        },
+        {
+            "id": "COEN-Avionics-Jan",
+            "heading": "and Embedded Systems"
+        }
+    ]
+}

--- a/webscraping/node/course-seq/scraper.js
+++ b/webscraping/node/course-seq/scraper.js
@@ -28,7 +28,9 @@ const programs = {
     "BLDG": "Building Engineering",
     "CIVI": "Civil Engineering",
     "INDU": "Industrial Engineering",
-    "MECH": "Mechanical Engineering"
+    "MECH": "Mechanical Engineering",
+    "COEN": "Computer Engineering",
+    "ELEC": "Electrical Engineering"
 };
 
 const programOptions = {
@@ -41,7 +43,12 @@ const programOptions = {
     "InfoSys": "Information Systems",
     "Stats": "Mathematics and Statistics",
     "SoftSys": "Software Systems",
-    "CompArts": "Computation Arts"
+    "CompArts": "Computation Arts",
+    "NoOption": "No",
+    "Tele": "Telecommunications",
+    "Electronics": "Electronics/VLSI",
+    "Avionics": "Avionics and Control Systems",
+    "Power": "Power and Renewable Energy"
 };
 
 const entryTypes = {
@@ -172,7 +179,7 @@ function scrapeElecCoenUrl(url, headings, outPath){
                 let yearList = toYearList(semesterList);
 
                 let sequenceObject = {
-                    "prettyName": sequence.prettyName,
+                    "prettyName": prettifySequenceID(sequence.id),
                     "sourceUrl": url,
                     "minTotalCredits" : minTotalCredits,
                     "yearList" : yearList
@@ -207,7 +214,6 @@ function splitElecCoenText(pageText, headings){
 
         sequenceTextObjects.push({
             "id": heading.id,
-            "prettyName": heading.heading,
             "sequenceText": sequenceText
         });
 

--- a/webscraping/node/course-seq/scraper.js
+++ b/webscraping/node/course-seq/scraper.js
@@ -4,11 +4,25 @@ let fs = require('fs');
 let request = require('request');
 let cheerio = require('cheerio');
 let assert = require('assert');
-let courseCodeRegex = /\w{4}\s?\d{3}/;
 
 const SEASON_NAMES = ["fall", "winter", "summer"];
+const outputDir = "./sequences/";
 
-let programs = {
+const courseCodeRegex = /\w{4}\s?\d{3}/;
+const minTotalCreditsRegex = /\S*\d+\S*/;
+const seasonRegex = /fall|winter|summer/i;
+const workTermRegex = /work term/i;
+const orListRegex = /\bor\b/i;
+const genElectiveRegex = /general/i;
+const nextLineSkipRegex = /gen_ed|coen050/i;
+const scienceElectiveRegex = /basic science/i;
+const programElectiveRegex = /elective/i;
+const garbageLineRegex = /^\*|^note:|^suggested|^engineering writing test|^refer/i;
+
+const commonSequenceSelector = ".c-accordion.toggable";
+const elecCoenSequenceSelector = ".WordSection1";
+
+const programs = {
     "SOEN": "Software Engineering",
     "COMP": "Computer Science",
     "BLDG": "Building Engineering",
@@ -17,7 +31,7 @@ let programs = {
     "MECH": "Mechanical Engineering"
 };
 
-let programOptions = {
+const programOptions = {
     "General": "General Program",
     "Games": "Computer Games",
     "Realtime": "Real-time, Embedded and Avionics Software ",
@@ -26,10 +40,11 @@ let programOptions = {
     "CompSys": "Computer Systems",
     "InfoSys": "Information Systems",
     "Stats": "Mathematics and Statistics",
-    "SoftSys": "Software Systems"
+    "SoftSys": "Software Systems",
+    "CompArts": "Computation Arts"
 };
 
-let entryTypes = {
+const entryTypes = {
     "Sept": "September",
     "Jan": "January",
     "Coop": "Coop September"
@@ -38,8 +53,9 @@ let entryTypes = {
 // pull all html documents from sequenceUrls.json and write to appropriate .json files
 let scrapeAllUrls = (function (){
 
-    let outputDir = "./sequences/";
     let numStarted = 0, numCompleted = 0;
+
+    console.log("\n** Scraping commonly-formatted sequences from sequenceUrls.json **\n");
 
     fs.readFile("./sequenceUrls.json", function (err, data) {
         if (err) {
@@ -50,11 +66,13 @@ let scrapeAllUrls = (function (){
         let sequenceUrls = JSON.parse(data.toString());
 
         // do some logging each time a sequence is finished with
-        let completionCallback = function(){
+        let completionCallback = function(plainFileName){
             numCompleted++;
-            console.log(numCompleted + "/" + numStarted + " file writes completed");
+            console.log("Done writing file: " + plainFileName + " (" + numCompleted + "/" + numStarted + ")");
             if(numCompleted == numStarted){
-                console.log("All file writes have been completed.");
+
+                console.log("\n** Scraping weirdly-formatted sequences from elecCoenHeadings.json **\n");
+                startElecCoenScrape();
             }
         };
 
@@ -73,9 +91,9 @@ let scrapeAllUrls = (function (){
                     }
                 }
             } else {
-                for(let sequenceVariant in subList){
+                for (let sequenceVariant in subList) {
                     let url = subList[sequenceVariant];
-                    let plainFileName =  program + "-" + sequenceVariant + ".json";
+                    let plainFileName = program + "-" + sequenceVariant + ".json";
                     numStarted++;
                     scrapeEncsSequenceUrl(url, outputDir, plainFileName, completionCallback);
                 }
@@ -84,6 +102,19 @@ let scrapeAllUrls = (function (){
     });
 })();
 
+function startElecCoenScrape(){
+    fs.readFile("./elecCoenHeadings.json", function (err, data) {
+        if (err) {
+            console.error("ERROR reading elecCoenHeadings.json");
+            process.exit(1);
+        }
+
+        let elecCoen = JSON.parse(data.toString());
+        scrapeElecCoenUrl(elecCoen.url, elecCoen.headings, outputDir);
+
+    });
+}
+
 // pull html document from url and write to appropriate .json files
 function scrapeEncsSequenceUrl(url, outPath, plainFileName, onComplete){
 
@@ -91,122 +122,9 @@ function scrapeEncsSequenceUrl(url, outPath, plainFileName, onComplete){
         if(!error){
             let $ = cheerio.load(html);
 
-            let semesterList = [];
-            let courseList = [];
-            let currentSeason = "";
-            let hasStartedScraping = false;
-            let minTotalCredits = $(".section.title .section-header").text().match(/\S*\d+\S*/)[0];
+            let minTotalCredits = $(".section.title .section-header").text().match(minTotalCreditsRegex)[0];
 
-            $(".concordia-table.table-condensed tbody > tr").each(function(i, el){
-                let $row = $(this);
-
-                if(i === 0){
-                    let seasonText = $(this).children().html().toLowerCase();
-                    currentSeason = parseSeason(seasonText);
-                }
-
-                if($row.children().length === 3){
-                    $row.each(function(i, el){
-                        let $rowCell = $(this);
-                        let containsBoldText = $rowCell.children()[0].name === "th";
-                        if(!containsBoldText){
-                            let code = "", name = "", isElective = "false", electiveType = "", credits = "", foundACourse = false;
-                            let firstCellText = $rowCell.find("p").text() || $rowCell.find("td").text();
-                            firstCellText = firstCellText.toLowerCase().trim();
-                            let pattern = new RegExp(/\bor\b/);
-                            let courseCodeValue = $($rowCell.children()[0]).text().replace(/\r?\n|\r/g, " ").trim().toLowerCase();
-
-                            if(firstCellText.indexOf("work term") >= 0){
-                                semesterList.push({
-                                    "season": currentSeason,
-                                    "courseList": courseList,
-                                    "isWorkTerm": "true"
-                                });
-                            } else if(pattern.test(courseCodeValue)){
-                                let orList = courseCodeValue.split(/\bor\b/);
-                                let orCourseList = [];
-                                orList.forEach(function(courseCode){
-                                    let isElec = "false", elecType = "";
-                                    if(firstCellText.indexOf("basic science") >= 0){
-                                        courseCode = "";
-                                        isElec = "true";
-                                        elecType = "Science";
-                                    } else if(courseCode.indexOf("general") >= 0){
-                                        courseCode = "";
-                                        isElec = "true";
-                                        elecType = "General";
-                                    } else if(courseCode.indexOf("elective") >= 0){
-                                        courseCode = "";
-                                        isElec = "true";
-                                        elecType = "Program";
-                                    } else {
-                                        courseCode = extractCourseCode(courseCode);
-                                    }
-                                    courseCode = addMiddleSpaceIfNeeded(courseCode);
-                                    orCourseList.push({
-                                        "code": courseCode.trim().toUpperCase(),
-                                        "isElective": isElec.trim(),
-                                        "electiveType": elecType.trim()
-                                    });
-                                });
-                                courseList.push(orCourseList);
-                            } else if(firstCellText.indexOf("basic science") >= 0){
-                                isElective = "true";
-                                electiveType = "Science";
-                                foundACourse = true;
-                            } else if(firstCellText.indexOf("general") >= 0){
-                                isElective = "true";
-                                electiveType = "General";
-                                foundACourse = true;
-                            } else if(firstCellText.indexOf("elective") >= 0){
-                                isElective = "true";
-                                electiveType = "Program";
-                                foundACourse = true;
-                            } else {
-                                // add a course to the course list
-                                code = extractCourseCode($($rowCell.children()[0]).text());
-                                foundACourse = true;
-                            }
-                            if(foundACourse && (code.trim().length > 0) || electiveType.trim().length > 0){
-                                code = addMiddleSpaceIfNeeded(code);
-                                courseList.push({
-                                    "code": code.trim().toUpperCase(),
-                                    "isElective": isElective.trim(),
-                                    "electiveType": electiveType.trim()
-                                });
-                            }
-                        }
-                    });
-                } else if(/work term [i]+/g.test($row.children().text().toLowerCase())){
-                    semesterList.push({
-                        "season": currentSeason,
-                        "courseList": courseList,
-                        "isWorkTerm": "true"
-                    });
-                }else if($row.children().text().toLowerCase().indexOf("year") >= 0){
-                    if(hasStartedScraping){
-                        if(courseList.length > 0){
-                            semesterList.push({
-                                "season": currentSeason,
-                                "courseList": courseList,
-                                "isWorkTerm": "false"
-                            });
-                        }
-                        courseList = [];
-                        currentSeason = parseSeason($row.children().text().toLowerCase());
-                    }
-                    hasStartedScraping = true;
-                }
-            });
-
-            // add residual semester if there is one
-            if(courseList.length > 0){
-                semesterList.push({
-                    "season": currentSeason,
-                    "courseList": courseList,
-                    "isWorkTerm": "false"
-                });
-            }
+            let semesterList = sequenceTextToSemesterList($(commonSequenceSelector).text());
 
             semesterList = fixMechAndIndu(semesterList, plainFileName);
 
@@ -219,20 +137,234 @@ function scrapeEncsSequenceUrl(url, outPath, plainFileName, onComplete){
                 "yearList" : yearList
             };
 
-            console.log("Finished scraping from url: " + url);
-
             fs.writeFile(outPath + plainFileName, JSON.stringify(sequenceObject, null, 4), function(err){
                 if(err){
                     console.error("ERROR writing to a file: " + plainFileName);
                     process.exit(1);
                 } else {
-                    console.log("Done writing file: " + plainFileName);
-                    onComplete && onComplete();
+                    onComplete && onComplete(plainFileName);
                 }
             });
 
         }
     });
+}
+
+function scrapeElecCoenUrl(url, headings, outPath){
+
+    request(url, function(error, response, html){
+        if(!error){
+            let $ = cheerio.load(html);
+
+            let pageText = $(elecCoenSequenceSelector).text();
+
+            let sequenceTextObjects = splitElecCoenText(pageText, headings);
+
+            let numCompleted = 0;
+
+            sequenceTextObjects.forEach((sequence, sequenceIndex) => {
+
+                let semesterList = sequenceTextToSemesterList(sequence.sequenceText);
+
+                // assume 120 credits for engineering
+                let minTotalCredits = "120";
+
+                let yearList = toYearList(semesterList);
+
+                let sequenceObject = {
+                    "prettyName": sequence.prettyName,
+                    "sourceUrl": url,
+                    "minTotalCredits" : minTotalCredits,
+                    "yearList" : yearList
+                };
+
+                fs.writeFile(outPath + sequence.id + ".json", JSON.stringify(sequenceObject, null, 4), function(err){
+                    if(err){
+                        console.error("ERROR writing to a file: " + sequence.id);
+                        process.exit(1);
+                    } else {
+                        numCompleted++;
+                        console.log("Done writing file: " + sequence.id + ".json (" + numCompleted + "/" + (sequenceTextObjects.length) + ")");
+                    }
+                });
+            });
+        }
+    });
+}
+
+function splitElecCoenText(pageText, headings){
+
+    let sequenceTextObjects = [];
+    let lastHeadingIndex = pageText.indexOf("ELEC Regular, September Entry");
+
+    headings.forEach((heading, headingIndex) => {
+
+        let currentHeadingIndex = pageText.indexOf(heading.heading, lastHeadingIndex);
+        let nextHeadingIndex = (headingIndex !== headings.length - 1) ? pageText.indexOf(headings[headingIndex + 1].heading, currentHeadingIndex) : pageText.length - 1;
+        let sequenceText = pageText.substring(currentHeadingIndex, nextHeadingIndex);
+
+        lastHeadingIndex = nextHeadingIndex;
+
+        sequenceTextObjects.push({
+            "id": heading.id,
+            "prettyName": heading.heading,
+            "sequenceText": sequenceText
+        });
+
+    });
+
+    return sequenceTextObjects;
+}
+
+function sequenceTextToSemesterList(sequenceText){
+
+    let semesterList = [];
+
+    let inOrList = false;
+
+    let currentSeason = "";
+    let currentCourseList = [];
+    let currentIsWorkTerm = "false";
+
+    let allLines = sequenceText.split("\n");
+    for(let lineIndex = 0; lineIndex < allLines.length; lineIndex++){
+        let line = allLines[lineIndex].trim();
+        if(line.length > 0 && !(line.match(garbageLineRegex))){
+            let seasonMatch = line.match(seasonRegex);
+            if(seasonMatch){
+
+                // flush list
+                if(currentSeason.length > 0){
+                    semesterList.push({
+                        "season": currentSeason,
+                        "courseList": currentCourseList,
+                        "isWorkTerm": currentIsWorkTerm
+                    });
+                }
+
+                // change season and restart
+                currentSeason = seasonMatch[0].toLowerCase();
+                currentCourseList = [];
+                currentIsWorkTerm = "false";
+
+            } else {
+
+                // force skip the next line if the current line format calls for it
+                if(line.match(nextLineSkipRegex)){
+                    lineIndex++;
+                }
+
+                let workTermMatch = line.match(workTermRegex);
+                if(workTermMatch){
+                    currentIsWorkTerm = "true";
+                }
+
+                let courseItem = extractCourseObject(line);
+
+                if(courseItem){
+
+                    let orListMatch = line.match(orListRegex);
+
+                    if(orListMatch){
+
+                        let singleLineOrList = line.split(orListRegex);
+
+                        let allValid = true;
+
+                        // check that there are at least two courses
+                        singleLineOrList.forEach((orListItem) => {
+                            if(!extractCourseObject(orListItem)){
+                                allValid = false;
+                            }
+                        });
+
+                        // This orList is on one line
+                        if(singleLineOrList.length > 1 && allValid){
+
+                            let orList = [];
+                            singleLineOrList.forEach((courseText) => {
+                                let courseOrItem = extractCourseObject(courseText);
+                                courseOrItem && orList.push(courseOrItem);
+                            });
+
+                            if(orList.length > 1) {
+                                currentCourseList.push(orList);
+                            }
+                        }
+                        // This is a multi-line orList, so use inOrList boolean
+                        else {
+
+                            if(!inOrList){
+                                currentCourseList.push([]);
+                                inOrList = true;
+                            }
+
+                            if(inOrList){
+                                currentCourseList[currentCourseList.length-1].push(courseItem);
+                            } else {
+                                currentCourseList.push(courseItem);
+                            }
+                        }
+                    }
+                    else {
+                        if(inOrList){
+                            currentCourseList[currentCourseList.length-1].push(courseItem);
+                        }
+                        else {
+                            currentCourseList.push(courseItem);
+                        }
+                        inOrList = orListMatch;
+                    }
+                }
+            }
+        }
+    }
+    // add residual semester
+    semesterList.push({
+        "season": currentSeason,
+        "courseList": currentCourseList,
+        "isWorkTerm": currentIsWorkTerm
+    });
+    return semesterList;
+}
+
+function extractCourseObject(text){
+
+    let genElectiveMatch = text.match(genElectiveRegex);
+    let scienceElectiveMatch = text.match(scienceElectiveRegex);
+    let programElectiveMatch = text.match(programElectiveRegex);
+    let courseMatch = text.match(courseCodeRegex);
+
+    if(scienceElectiveMatch){
+        return {
+            "code": "",
+            "isElective": "true",
+            "electiveType": "Science"
+        };
+    }
+    else if(genElectiveMatch){
+        return {
+            "code": "",
+            "isElective": "true",
+            "electiveType": "General"
+        };
+    }
+    else if(programElectiveMatch){
+        return {
+            "code": "",
+            "isElective": "true",
+            "electiveType": "Program"
+        };
+    }
+    else if(courseMatch){
+        return {
+            "code": addMiddleSpaceIfNeeded(courseMatch[0].toUpperCase()),
+            "isElective": "false",
+            "electiveType": ""
+        };
+    }
+
+    return undefined;
 }
 
 // converts a list of semesters into a list of years, ensuring that each year has a fall, winter and summer semester object
@@ -310,8 +442,8 @@ function fixMechAndIndu(semesterList, programID){
 
         // clear messed up semesters
         semesterList.pop();
+        semesterList.pop();
         if(!programID.includes("Coop")) {
-            semesterList.pop();
             semesterList.push(emptyWinter);
         }
 

--- a/webscraping/node/course-seq/sequenceUrls.json
+++ b/webscraping/node/course-seq/sequenceUrls.json
@@ -63,6 +63,9 @@
         "Sept": "https://www.concordia.ca/encs/computer-science-software-engineering/students/course-sequences/sept-web-svcs.html",
         "Jan": "https://www.concordia.ca/encs/computer-science-software-engineering/students/course-sequences/jan-web-svcs.html",
         "Coop": "https://www.concordia.ca/encs/computer-science-software-engineering/students/course-sequences/coop-web-svcs.html"
+      },
+      "CompArts": {
+        "Sept": "https://www.concordia.ca/encs/computer-science-software-engineering/students/course-sequences/sept-comp-arts.html"
       }
     }
   },


### PR DESCRIPTION
### ~Please merge pull request #83 before reviewing this PR.~
## Summary
I've added 21 new sequences from the `ELEC` and `COEN` program types. The sequences for these programs were formatted completely differently on the concordia website [as you can see](http://users.encs.concordia.ca/~eceweb/docs/ECE_CourseSequence_2016-2017.htm).

I also simplified/improved the output of the sequence scraper.

To accomplish this, I needed to rewrite the webscraper to include a function which could successfully parse both the old sequence format and the new sequence format. The easiest way to do this was to stop using `cheerio` and navigate through the text directly with the help of some regexes. The fact that all these `ELEC` and `COEN` sequences were contained on one page with no convenient css class names to jump to further complicated things.

I also added 1 other sequence: COMP [Computation Arts](https://www.concordia.ca/encs/computer-science-software-engineering/students/course-sequences/sept-comp-arts.html) but a lot of the courses are missing from the DB 😢, see #86 

We now support 69 recommended sequences in total. You can test them all on [courseplannerd](http://138.197.6.26/courseplannerd/)