### PR TITLE
Fix course info scraper 84

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.idea/
 /target/
 node_modules/
+package-lock.json
 
 /src/main/webapp/sequences/
 /src/main/webapp/bundle.js

--- a/webscraping/r/course-info-data-sources.txt
+++ b/webscraping/r/course-info-data-sources.txt
@@ -169,4 +169,3 @@ http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-550.ht
 WSDB
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-560.html
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(14)
-

--- a/webscraping/r/course-info-data-sources.txt
+++ b/webscraping/r/course-info-data-sources.txt
@@ -169,3 +169,4 @@ http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-550.ht
 WSDB
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-560.html
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(14)
+

--- a/webscraping/r/course-info-data-sources.txt
+++ b/webscraping/r/course-info-data-sources.txt
@@ -88,9 +88,6 @@ http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-100.ht
 TESL
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-090.html#b31.090.1
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(21)
-FRAN
-http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-110.html
-#content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)
 CATA
 http://www.concordia.ca/academics/undergraduate/calendar/current/sec31/31-120.html
 #content-main > div > div > div.span8.ordinal-group-1 > div.parsys.content-main > div.parbase.section.wysiwyg > div > p:nth-child(13)

--- a/webscraping/r/scrape-course-data.r
+++ b/webscraping/r/scrape-course-data.r
@@ -45,7 +45,7 @@ for(i in 1:num.scrapes) {
     course.code.rgx <- '[A-Z]{4} [0-9]{3}'
     course.name.rgx <- '[A-Z][a-z][^(]*'
     credits.rgx <- '\\(([0-9](\\.[0-9]{1,2})?) credits?\\)'
-    prereqs.rgx <- 'Prerequisite: ([^.]*.)'
+    prereqs.rgx <- 'Prerequisite: ([^.]*\\.)'
 
     # extracting the regexes to new columns in the program.courses data frame
     program.courses <- program.courses %>% # str_extract only takes first occurence of regex


### PR DESCRIPTION
### Why I made this issue/PR
This issue/PR was needed to unblock work I was doing in [validateCourseInfoScrape-76](/stumash/CoursePlanner/tree/validateCourseInfoScrape-76).  As I was finishing up writing the validator, I noticed that it was actually successfully catching invalid course info!  I didn't want to merge the json validator branch without letting it do one complete no-errors-found run-through, so even though the problem was with the scraped data and not the validation (probably), I resolved to first fix the scraper and then move back to the validator.

### What changed
Looking through some of the scraped data and the webpages it came from, I found that the courses that were being badly scraped/were badly formatted online/need to be scraped from elsewhere were all missing the `description` property in the scraped json.  So, I added some logic that prevents such courses from being written to the file our `storer.js` scripts use to add json to the mongodb.  That is all.  Now I will resume work on the validator, which will no longer send us annoying emails regarding bad data.  This is good because we only want to be emailed about failed scraping on good data, not failed scraping on data we should ignore.
The `scrape-course-data.r` file now outputs a list of courses that don't have `description`s.

:straight_ruler: 