### PR TITLE
Fix course info scraper 84

### DIFF
--- a/webscraping/r/scrape-course-data.r
+++ b/webscraping/r/scrape-course-data.r
@@ -15,8 +15,7 @@ urls          <- urls.and.css.selectors[seq(from = 2, to = length(urls.and.css.s
 css.selectors <- urls.and.css.selectors[seq(from = 3, to = length(urls.and.css.selectors), by = 3)]
 rm(urls.and.css.selectors)
 
-# for(i in 1:num.scrapes) {
-    i <- which(program.names == "HIST")
+for(i in 1:num.scrapes) {
     # print(i)
     # print(program.name[i])
 
@@ -25,8 +24,8 @@ rm(urls.and.css.selectors)
         html_node(css = css.selectors[i]) # extract desired DOM
 
     # match "course info header" of each course on concordia web site
-    # ...something like 'SOEN 555    Systems'
-    course.info.header.rgx <- "[A-Z]{4} [0-9]{3}[[:space:]]+?[A-Z][a-z]+."
+    # ...something like 'SOEN 555    Systems'. Might have a '(also listed as AAAA 1111)' before the course name.
+    course.info.header.rgx <- "[A-Z]{4} [0-9]{3}[[:space:]]+?(\\(also listed as [^)]*\\))?[A-Z][a-z]+."
 
     # split text on empty string before each course.info.header.rgx match, convert to data frame
     program.courses <- html_text(program.html.string) %>%

--- a/webscraping/r/scrape-course-data.r
+++ b/webscraping/r/scrape-course-data.r
@@ -82,7 +82,6 @@ for(i in 1:num.scrapes) {
         mutate(labHours = program.courses$secondhalf.string %>% str_match(laboratory.rgx) %>% .[,2])
     program.courses <- program.courses %>%
         mutate(note = program.courses$secondhalf.string %>% str_match(note.rgx) %>% .[,2])
-    program.courses$description
 
     #### BEGIN PARSING PREREQ STRING INTO JSON OBJECT
     # temp variable for prereq strings

--- a/webscraping/r/scrape-course-data.r
+++ b/webscraping/r/scrape-course-data.r
@@ -15,7 +15,8 @@ urls          <- urls.and.css.selectors[seq(from = 2, to = length(urls.and.css.s
 css.selectors <- urls.and.css.selectors[seq(from = 3, to = length(urls.and.css.selectors), by = 3)]
 rm(urls.and.css.selectors)
 
-for(i in 1:num.scrapes) {
+# for(i in 1:num.scrapes) {
+    i <- which(program.names == "HIST")
     # print(i)
     # print(program.name[i])
 
@@ -64,15 +65,16 @@ for(i in 1:num.scrapes) {
       mutate(secondhalf.string = program.courses$fullstring %>% str_match(secondhalf.rgx) %>% .[,3])
 
     # some regexes for data extraction from column 'secondhalf.string'
-    lectures.rgx <- 'Lectures: ([^.]*)'
-    tutorials.rgx <- 'Tutorial: ([^.]*)'
-    laboratory.rgx <- 'Laboratory: ([^.]*)'
-    note.rgx <- 'NOTE: (.*)'
-    course.description.rgx <- '.*?(?=(Lecture|Tutorial|Laboratory|\nNOTE|$))'
+    lectures.rgx <- 'Lectures: ([^.]*)' # Everything following 'Lectures ' up until first '.'
+    tutorials.rgx <- 'Tutorial: ([^.]*)' # Everything following 'Tutorial ' up until first '.'
+    laboratory.rgx <- 'Laboratory: ([^.]*)' # Everything following 'Laboratory ' up until first '.'
+    note.rgx <- 'NOTE: (.*)' # Everything following 'NOTE: ' up until first '.'
+    # Everything up until any of 'Lecture','Tutorial','Laboratory','NOTE', or <end of string>. Whichever comes first.
+    course.description.rgx <- '(.*?)(Lecture|Tutorial|Laboratory|NOTE|$)'
 
     # extracting the regex to new columns in the program.courses data frame
     program.courses <- program.courses %>%
-        mutate(description = program.courses$secondhalf.string %>% str_extract(course.description.rgx))
+        mutate(description = program.courses$secondhalf.string %>% str_match(course.description.rgx) %>% .[,2])
     program.courses <- program.courses %>%
         mutate(lectureHours = program.courses$secondhalf.string %>% str_match(lectures.rgx) %>% .[,2])
     program.courses <- program.courses %>%
@@ -81,6 +83,7 @@ for(i in 1:num.scrapes) {
         mutate(labHours = program.courses$secondhalf.string %>% str_match(laboratory.rgx) %>% .[,2])
     program.courses <- program.courses %>%
         mutate(note = program.courses$secondhalf.string %>% str_match(note.rgx) %>% .[,2])
+    program.courses$description
 
     #### BEGIN PARSING PREREQ STRING INTO JSON OBJECT
     # temp variable for prereq strings


### PR DESCRIPTION
2 changes to regexes

### First Change
The `course.info.header.rgx` was:
`[A-Z]{4} [0-9]{3}[[:space:]]+?[A-Z][a-z]+.`, but is now:
`[A-Z]{4} [0-9]{3}[[:space:]]+?(\\(also listed as [^)]*\\))?[A-Z][a-z]+.`

We use this regex to identify the start of a single course's information.  Some course's information starts with something like:
`COMP 101 (also listed as SOEN 101) Intro. to Programming` instead of:
`COMP 101 Intro. to Programming`.

### Second change
The `course.description.rgx` was:
`.*?(?=(Lecture|Tutorial|Laboratory|\nNOTE|$))`, but is now:
`(.*?)(Lecture|Tutorial|Laboratory|NOTE|$)`

The previous regex was essentially broken and was trying to achieve the result of the new one.
The new regex will match the entire string up until the first occurence of either `Lecture`,`Tutorial`,`Laboratory`, `NOTE`, or `$` (end of string).

resolves #84 