### PR TITLE
Prettified JSON output in courseplanner debug emails

### DIFF
--- a/webscraping/courseSequences/storing/storer.js
+++ b/webscraping/courseSequences/storing/storer.js
@@ -48,7 +48,7 @@ const storeAllSequences = (function (){
                     numValidated++;
                     if(!isSequenceValid){
                         logMessage(file + ": FAIL - ");
-                        logMessage(JSON.stringify(validate.errors, undefined, 4));
+                        logMessage('<pre>' + JSON.stringify(validate.errors, undefined, 4) + '</pre>');
                         foundIssue = true;
                     } else {
                         logMessage(file + ": PASS");
@@ -88,7 +88,7 @@ function logMessage(message){
 
 function sendIssueEmail(){
 
-    let message = "The course sequence scraper encountered errors in its most recent execution (" + new Date().toString() + ")\n" +
+    let message = "The course sequence scraper encountered errors in its most recent execution (" + new Date().toString() + ")<br>" +
                     " Below are the logs from the scrape attempt:<br><br>";
     message += log;
 


### PR DESCRIPTION
This PR resolves #87 

All it took was to wrap the JSON with `<pre>` tags to preserve the whitespace.
There was also a `\n` character that wasn't being translated to a newline in the email, so I replaced that with a `<br>` make a newline appear there in the email.

Creds to this [answer](https://stackoverflow.com/questions/16862627/json-stringify-output-to-div-in-pretty-print-way).

This PR is so tiny, I have nothing else to say but:
![mrtseeks](https://user-images.githubusercontent.com/19865282/30001547-479fea78-905f-11e7-8465-c9f2670eecc3.jpg)
