### PR TITLE
Changed final war name of prod to ROOT.war

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -82,13 +82,19 @@ echo ""
 
 # transfer the built project onto the VM
 # this will trigger Tomcat to reload the site content
-deployToServerCommand="scp ./target/courseplanner.war david@138.197.6.26:/opt/tomcat/webapps/courseplanner${devname}.war"
-echo "copying .war file to server..."
-if eval $deployToServerCommand $verbose # run the deployment command and react to exit code
+deployToServerCommand="scp ./target/courseplanner.war david@138.197.6.26:/opt/tomcat/webapps/"
+if $prod
 then
-    echo "copying courseplanner${devname}.war to server successful at: $(date)"
+    finalWarName="ROOT.war"
 else
-    echo "copying courseplanner${devname}.war to server failed at: $(date)"
+    finalWarName="courseplanner${devname}.war"
+fi
+echo "copying .war file to server..."
+if eval $deployToServerCommand$finalWarName $verbose # run the deployment command and react to exit code
+then
+    echo "copying ${finalWarName} to server successful at: $(date)"
+else
+    echo "copying ${finalWarName} to server failed at: $(date)"
     echo "deploy.sh failed"
     exit 1
 fi

--- a/src/main/webapp/404.html
+++ b/src/main/webapp/404.html
@@ -9,7 +9,7 @@
 		<div class= "header" id="header-text" >
 			<h1 class="error" id="main">
 			Error 404! Page does does not exist. 
-			<br><a href="index.html">Homepage</a> 
+			<br><a href="/index.html">Homepage</a>
 			<!--link to homepage-->
 			</h1>
 		</div>

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -20,7 +20,7 @@ export const ITEM_TYPES = {
 // All hardcoded pieces of text which are directly displayed to the user
 export const UI_STRINGS = {
 
-    "SITE_NAME": "Conu Course Planner",
+    "SITE_NAME": "ConU Course Planner",
 
     "WORK_TERM": "Work Term",
     "IS_WORK_TERM": " is work term?",


### PR DESCRIPTION
resolves issue #97 
## Summary
This change involed two steps:
1. Renamed the file `/opt/tomcat/webapps/courseplanner.war` to `/opt/tomcat/webapps/ROOT.war`
2. Updated the deploy script to produce the final file name `ROOT.war` instead of `courseplanner.war` when deploying for `prod`. Development deployment operation remains identical.

By default, if Tomcat finds a ROOT.war in its `webapps` dir then it will serve the webapp contained in that war file at the "root" of the site (AKA `conucourseplanner.online/`).

I also made some very minor changes to our 404 page and the name of the "site logo" as peter suggested a capital U would be better.
## Test
Nothing really to test, unless u wanna `ll /opt/tomcat/webapps/` to view the new `ROOT.war`