### PR TITLE
Added authentication for mongoDB

### DIFF
--- a/src/main/resources/courseplanner.properties
+++ b/src/main/resources/courseplanner.properties
@@ -2,7 +2,7 @@ buildType = ${buildType}
 
 dbNameDev = courseplannerdb-dev
 dbNameProd = courseplannerdb
-mongoUrl = mongodb://138.197.6.26:27017
+mongoUrl = mongodb://username:password@conucourseplanner.online:27017/?authSource=admin
 courseDataCollectionName = courseData
 courseSequenceCollectionName = courseSequences
 

--- a/webscraping/scrapeTheWeb.sh
+++ b/webscraping/scrapeTheWeb.sh
@@ -21,7 +21,7 @@ node scraper.js
 
 # run storer for course sequences
 cd $webscrapedir/courseSequences/storing
-node storer.js "${1}"
+node storer.js "$@"
 
 # Course Info:
 
@@ -37,4 +37,4 @@ Rscript scrapeCourseInfo.r
 
 # run storer for course data
 cd "$webscrapedir/courseInfo/storing"
-node storer.js "${1}"
+node storer.js "$@"


### PR DESCRIPTION
## Summary
Previously our mongoDB server was running without authentication which was an issue lulululul.

To fix this, I've created two users that are allowed to interact with the DB: 
### User 1

```
username: username, password: password

- has read-only access to both dev and prod dbs
```
The back-end of our site now signs into the DB using these credentials. By using this user, anybody in the world can read our DB contents but will not be able to change them
### User 2
```
username: tranzoneAdmin, password: {see private gist or slack for password}

- has read-write access to both dev and prod dbs
- also has the rights to perform admin operations such as adding new users
```
The webscraper now signs into the DB using these credentials since it needs to write to the DB. Only people who know the password for this account will be able to edit our DB.

### How to run new webscraper

The webscraper storers now expect an additional argument for the db password. Examples on how to run scrapers now:
```
sh scrapeTheWeb.sh "$(< ~/tranzoneAdminPass.txt)"
```
```
sh scrapeTheWeb.sh "$(< ~/tranzoneAdminPass.txt)" --prod
```
I updated the crontab on our server to include our new password in anticipation of the merging of this PR.
## Test
You can check that the back-end is working again by testing an API call on my webspace : http://www.conucourseplanner.online/courseplannerd/allsequences (you should not get 500 error or empty array)

You can also check that webscraping is working by grabbing the password and running `scrapeTheWeb.sh`. As long as it outputs "Connected successfully to db server" were good.