### PR TITLE
Add undo/redo

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "browserify": "^14.4.0",
     "bundle-collapser": "^1.2.1",
     "envify": "^4.1.0",
+    "react": "^15.6.1",
+    "react-dnd": "^2.4.0",
+    "react-dnd-html5-backend": "^2.4.1",
+    "react-dom": "^15.6.1",
     "uglify-js": "^3.0.25",
     "uglifyify": "3.0.4",
-    "react-dnd": "^2.4.0",
-    "react-dnd-html5-backend": "^2.4.1"
+    "underscore": "^1.8.3"
   }
 }

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -8,6 +8,8 @@ import {SemesterList} from "./semesterList";
 import {IOPanel} from "./ioPanel";
 import {DEFAULT_PROGRAM, saveAs, generateUniqueKey, generateUniqueKeys} from "./util";
 
+let _ = require('underscore');
+
 /*
  *  Root component of our main page
  *
@@ -47,6 +49,13 @@ class MainPage extends React.Component {
         this.loadAllSequences();
     }
 
+    componentDidUpdate(prevProps, prevState){
+        if(!_.isEqual(prevState.courseSequenceObject, this.state.courseSequenceObject) && !this.state.courseSequenceObject.isLoading){
+            // save change to local storage
+            localStorage.setItem("savedSequence", JSON.stringify(this.state.courseSequenceObject));
+        }
+    }
+
     /*
      *  function to call in the event that the user selects a new program of study
      *      param newChosenProgram - the name of the chosen program (e.g. SOEN-General-Coop);
@@ -57,7 +66,7 @@ class MainPage extends React.Component {
         // remember the program selected by the user
         localStorage.setItem("chosenProgram", newChosenProgram);
         // clear the saved sequence to force a reloading of the user's chosen program
-        // (INSERT CONFIRM BOX HERE - MAKE SURE USER DOESN'T LOSE THEIR WORK BY ACCIDENTALLY CHANGING PROGRAMS)
+        // TODO: (INSERT CONFIRM BOX HERE - MAKE SURE USER DOESN'T LOSE THEIR WORK BY ACCIDENTALLY CHANGING PROGRAMS)
         localStorage.removeItem("savedSequence");
 
         // Must use the callback param of setState to ensure the chosenProgram is changed in time
@@ -72,20 +81,19 @@ class MainPage extends React.Component {
     setOrListCourseSelected(coursePosition){
         this.setState((prevState) => {
 
+            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
+
             // update isSelected property of items in orList in question
-            let orList = prevState.courseSequenceObject.yearList[coursePosition.yearIndex][coursePosition.season].courseList[coursePosition.courseListIndex];
+            let orList = courseSequenceObjectCopy.yearList[coursePosition.yearIndex][coursePosition.season].courseList[coursePosition.courseListIndex];
 
             orList = orList.map((courseObj, orListIndex) => {
                 courseObj.isSelected = (orListIndex === coursePosition.orListIndex);
                 return courseObj;
             });
 
-            // save change to local storage
-            localStorage.setItem("savedSequence", JSON.stringify(prevState.courseSequenceObject));
-
             // set new state based on changes
             return {
-                "courseSequenceObject": prevState.courseSequenceObject
+                "courseSequenceObject": courseSequenceObjectCopy
             };
         });
     }
@@ -98,16 +106,15 @@ class MainPage extends React.Component {
     toggleWorkTerm(yearIndex, season){
         this.setState((prevState) => {
 
-            // updated isWorkTerm property of semester in question
-            let isWorkTerm = prevState.courseSequenceObject.yearList[yearIndex][season].isWorkTerm;
-            prevState.courseSequenceObject.yearList[yearIndex][season].isWorkTerm = (isWorkTerm === "true") ? "false" : "true";
+            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
 
-            // save change to local storage
-            localStorage.setItem("savedSequence", JSON.stringify(prevState.courseSequenceObject));
+            // updated isWorkTerm property of semester in question
+            let isWorkTerm = courseSequenceObjectCopy.yearList[yearIndex][season].isWorkTerm;
+            courseSequenceObjectCopy.yearList[yearIndex][season].isWorkTerm = (isWorkTerm === "true") ? "false" : "true";
 
             // set new state based on changes
             return {
-                "courseSequenceObject": prevState.courseSequenceObject
+                "courseSequenceObject": courseSequenceObjectCopy
             };
         });
     }
@@ -131,18 +138,17 @@ class MainPage extends React.Component {
     moveCourse(oldPosition, newPosition){
         this.setState((prevState) => {
 
-            let courseToMove = prevState.courseSequenceObject.yearList[oldPosition.yearIndex][oldPosition.season].courseList[oldPosition.courseListIndex];
+            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
+
+            let courseToMove = courseSequenceObjectCopy.yearList[oldPosition.yearIndex][oldPosition.season].courseList[oldPosition.courseListIndex];
 
             // remove course from old position and insert at new position
-            prevState.courseSequenceObject.yearList[oldPosition.yearIndex][oldPosition.season].courseList.splice(oldPosition.courseListIndex, 1);
-            prevState.courseSequenceObject.yearList[newPosition.yearIndex][newPosition.season].courseList.splice(newPosition.courseListIndex, 0, courseToMove);
-
-            // save change to local storage
-            localStorage.setItem("savedSequence", JSON.stringify(prevState.courseSequenceObject));
+            courseSequenceObjectCopy.yearList[oldPosition.yearIndex][oldPosition.season].courseList.splice(oldPosition.courseListIndex, 1);
+            courseSequenceObjectCopy.yearList[newPosition.yearIndex][newPosition.season].courseList.splice(newPosition.courseListIndex, 0, courseToMove);
 
             // set new state based on changes
             return {
-                "courseSequenceObject": prevState.courseSequenceObject
+                "courseSequenceObject": courseSequenceObjectCopy
             };
         });
     }
@@ -159,15 +165,14 @@ class MainPage extends React.Component {
             // generate a unique key for the course
             courseObj.id = generateUniqueKey(courseObj, newPosition.season, newPosition.yearIndex, newPosition.courseListIndex, "");
 
-            // insert course at new position
-            prevState.courseSequenceObject.yearList[newPosition.yearIndex][newPosition.season].courseList.splice(newPosition.courseListIndex, 0, courseObj);
+            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
 
-            // save change to local storage
-            localStorage.setItem("savedSequence", JSON.stringify(prevState.courseSequenceObject));
+            // insert course at new position
+            courseSequenceObjectCopy.yearList[newPosition.yearIndex][newPosition.season].courseList.splice(newPosition.courseListIndex, 0, courseObj);
 
             // set new state based on changes
             return {
-                "courseSequenceObject": prevState.courseSequenceObject
+                "courseSequenceObject": courseSequenceObjectCopy
             };
         });
     }
@@ -180,15 +185,14 @@ class MainPage extends React.Component {
     removeCourse(coursePosition){
         this.setState((prevState) => {
 
-            // remove course at coursePosition
-            prevState.courseSequenceObject.yearList[coursePosition.yearIndex][coursePosition.season].courseList.splice(coursePosition.courseListIndex, 1);
+            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
 
-            // save change to local storage
-            localStorage.setItem("savedSequence", JSON.stringify(prevState.courseSequenceObject));
+            // remove course at coursePosition
+            courseSequenceObjectCopy.yearList[coursePosition.yearIndex][coursePosition.season].courseList.splice(coursePosition.courseListIndex, 1);
 
             // set new state based on changes
             return {
-                "courseSequenceObject": prevState.courseSequenceObject
+                "courseSequenceObject": courseSequenceObjectCopy
             };
         });
     }

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -8,7 +8,7 @@ import {SemesterList} from "./semesterList";
 import {IOPanel} from "./ioPanel";
 import {DEFAULT_PROGRAM, MAX_UNDO_HISTORY_LENGTH, saveAs, generateUniqueKey, generateUniqueKeys} from "./util";
 
-let _ = require('underscore');
+let _ = require("underscore");
 
 /*
  *  Root component of our main page

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -57,6 +57,7 @@ class MainPage extends React.Component {
 
     componentDidUpdate(prevProps, prevState){
         if(!_.isEqual(prevState.courseSequenceObject, this.state.courseSequenceObject) && !this.state.courseSequenceObject.isLoading){
+            
             // save change to local storage
             localStorage.setItem("savedSequence", JSON.stringify(this.state.courseSequenceObject));
 
@@ -71,12 +72,6 @@ class MainPage extends React.Component {
                 }
             }
             this.preventHistoryUpdate = false;
-
-            console.group("Sequence Object History");
-            console.log("history length:", this.courseSequenceHistory.history.length);
-            console.log("current history position:", this.courseSequenceHistory.currentPosition);
-            console.log("pointing at:", this.courseSequenceHistory.history[this.courseSequenceHistory.currentPosition].yearList);
-            console.groupEnd();
         }
     }
 
@@ -253,7 +248,7 @@ class MainPage extends React.Component {
 
     render() {
         return (
-            <div className="row" tabIndex="1" onKeyDown={this.handleKeyPress}>
+            <div className="mainPage row" tabIndex="1" onKeyDown={this.handleKeyPress}>
                 <div className="col-md-3 col-sm-12">
                     <IOPanel courseInfo={this.state.selectedCourseInfo}
                              allSequences={this.state.allSequences}

--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -81,7 +81,7 @@ class SemesterBox extends React.Component {
                       title={UI_STRINGS.IS_WORK_TERM}
                       value="isWorkTerm"
                       onChange={this.handleWorkTermToggle}
-                      defaultChecked={(this.props.semester.isWorkTerm === "true")}/>;
+                      checked={(this.props.semester.isWorkTerm === "true")}/>;
 
     }
 

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -10,6 +10,7 @@ export const SEASON_NAMES_PRETTY = ["Fall", "Winter", "Summer"];
 export const SEASON_NAMES = SEASON_NAMES_PRETTY.map((season) => season.toLowerCase());
 export const DEFAULT_PROGRAM = "SOEN-General-Coop";
 export const EXPORT_TYPES = ["PDF", "MD", "TXT"];
+export const MAX_UNDO_HISTORY_LENGTH = 100;
 
 // Item types used for DND
 export const ITEM_TYPES = {

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -7,6 +7,10 @@
     font-size: 14px;
 }
 
+.mainPage:focus {
+    outline: none;
+}
+
 /* Styling for SemesterTable */
 
 .semesterTable tr > td:first-of-type {


### PR DESCRIPTION
resolves #104 
related to #45 

## Summary

As described in the issue, you can now undo changes with Control+Z and redo changes with Control+Shift+Z. This applies to any change made by the user to the `courseSequenceObject` which is the same object that's stored in local storage for persistence. This includes all actions that the user might do to change their sequence such as adding a course, moving a course, deleting a course, toggling a work term. For reference, the properties that `courseSequenceObject` has are the same as described in [courseSequenceSchema.json](/stumash/CoursePlanner/blob/master/webscraping/courseSequences/storing/courseSequenceSchema.json): `yearList`, `minTotalCredits`, `prettyName` and `sourceUrl`.

I added a new dependency called [underscore](http://underscorejs.org/) which I used to check if two js objects are equal to each other (`_.isEqual()`). It's so cool how browserify allows us to add any npm module we want via `npm install --save-dev` and just str8 use it in our frontend code.

## Test

You can test on http://www.conucourseplanner.online/courseplannerd/ as usual. Try to do weird stuff and let me know if it bugs out. I added some useful console.logs on there so you can see what's going on under the hood.