### PR TITLE
Add some missing courses

### DIFF
--- a/docs/missingCoursesNotes.md
+++ b/docs/missingCoursesNotes.md
@@ -1,0 +1,75 @@
+# Some notes regarded the courses that are missing in our DB
+
+[
+  "ENGR 418", - addressed
+  "FFAR 250", - addressed
+  "CART 255", - addressed
+  "CART 214", - addressed
+  "COMP 393", - addressed
+  "COMM 225", - addressed
+  "CART 211", - addressed
+  "COMM 222", - addressed
+  "ELEC 415", - addressed
+  "CART 212", - addressed
+  "CART 411", - addressed
+  "ACCO 220", - addressed
+  "COMM 223", - addressed
+  "BLDG 471", - addressed
+  "ELEC 416", - addressed
+  "CART 351", - addressed
+  "CART 412", - addressed
+  "COMM 210", - addressed
+  "COMM 308", - addressed
+  "MAST 224", - addressed
+  "ENGR 417", - addressed 
+  "COEN 451", - addressed
+  "MECH 490", - addressed
+  "MECH 480", - addressed
+  "MECH 482" - addressed
+]
+
+## To view the most recent list of missing courses, run the file `webscraping/courseSequences/storing/missingCourses.js`
+
+For all the courses that I found were missing, I either added it to `manualEntry.json` or wrote some notes about it below.
+
+### ENGR 418
+
+found the following info from this page: https://www.concordia.ca/content/dam/encs/docs/curriculum-letters/ELEC2014-2015.pdf
+
+ENGR 418 Integration of Avionics Systems; has been renamed AERO 483
+Integration of Avionics Systems
+
+Note that AERO 483 is indeed contained in our DB. Lord knows why they haven't updated the course sequence to account for this change.
+ 
+How can we deal with this problem?
+
+### COMP 393
+
+This course is listed ONLY in [Computer Science, Computer Games option, September entry](https://www.concordia.ca/encs/computer-science-software-engineering/students/course-sequences/sept-comp-games.html), and has the exact same description as the course ENCS 393.
+In other words, they made a mistake on the course sequence page and put COMP instead of ENCS lol. Idk how to fix this problem, but the fix would be the same as for ENGR 418.
+
+### ELEC 415
+
+This course has the same name as AERO 480 (Flight Control Systems).. Looks like the course was renamed just like ENGR 418
+
+### ELEC 416
+
+This course has the same name as AERO 482 (Avionic Navigation Systems).. Looks like the course was renamed just like ENGR 418
+
+### MAST 224
+
+This course has the same name as MAST 324 (Introduction to Optimization ).. Looks like the course was renamed just like ENGR 418
+I found hard proof for this one. These [two](https://www.concordia.ca/content/dam/artsci/math-stats/docs/Outlines%202014-2015/MAST224_4_14.pdf) [links](https://www.concordia.ca/content/dam/artsci/math-stats/docs/Outlines%202015-2016/MAST324_4_15.pdf) are virtually identical.
+
+### ENGR 417
+
+This course has the same name as ENGR 6421 (Avionic Navigation Systems).. It was changed to be a graduate class and should be entirely removed.
+
+### MECH 480 AND MECH 482
+
+These courses have the same names as AERO 480 and AERO 482 respectively (Flight Control Systems or Avionic Navigation Systems).. Looks like they were renamed just like ENGR 418
+I for proof for this one also: compare these [two](https://www.concordia.ca/encs/computer-science-software-engineering/students/course-sequences/sept-soen-real-time.html) [links](https://www.concordia.ca/encs/computer-science-software-engineering/students/course-sequences/sept-soen-real-time.html) for year 4 - fall
+
+
+
+

--- a/webscraping/courseInfo/storing/manualEntry.json
+++ b/webscraping/courseInfo/storing/manualEntry.json
@@ -1,1 +1,335 @@
-[]
+﻿[  
+    {  
+        "code":"FFAR 250",
+        "name":"Keywords: Reading the Arts Across the Disciplines",
+        "credits":"6",
+        "lectureHours":"three hours per week",
+        "description":"This course offers students with first-year standing in the Faculty of Fine Arts a broad introduction to ideas and aesthetics in the visual and performing arts in Canada. It focuses on key concepts shaping and shaped by artistic production and reception in all artistic disciplines. Students deepen their understanding of the cultural significance and the debate that occurs around keywords across the disciplines. Over the year, students extend their powers of reading, writing, and critical thinking in lectures and tutorials.",
+        "note":"This course is a BFA Degree requirement, and it is strongly recommended that students take it as part of their first year course selection.  The course will provide a wide ranging introduction to the visual and performing arts in the contemporary world. Emphasis will be placed on the interrelationships that exist among the arts, and the continuing impact of the past on the present. Much attention will be given to the contemporary arts in Canada and ever increasing cross-cultural awarenesses. Please note you MUST attend the lecture and tutorial in which you are registered.  All lectures will start the week of September 5, 2017.  Tutorials with a number (1) will meet for the first time the week of September 11, 2017, and every second week thereafter.  Tutorials with a number (2) will meet for the first time the week of September 18, 2017, and every second week thereafter. NOTE: The tutorial for this section will be taught in ENGLISH.",
+        "requirements":{  
+            "prereqs":[  
+
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"CART 255",
+        "name":"New Media Theory",
+        "credits":"3",
+        "lectureHours":"four hours per week",
+        "description":"This course is a critical introduction to new media theory focusing on issues of interaction, inscription, representation, code, reproduction, spectacle, control, body and resistance. Students develop tools to undertake a critical analysis of media and technology and their social, political, economic, and cultural ramifications.",
+        "requirements":{  
+            "prereqs":[  
+
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"CART 214",
+        "name":"A New Media Theory",
+        "credits":"3",
+        "lectureHours":"four hours per week",
+        "description":"Key themes of visual communication are explored in the context of computation arts. This studio course considers design elements such as line, pattern, shape, texture, interpretation of space, surface, perspective, dimension, repetition, randomness, colour and colour spaces, typography, drawing from observation, layout and composition and conceptualization. This class is predominantly non-digital and discusses the relationships between analog and digital approaches.",
+        "note":"Students who have received credit for CART 254 may not take this course for credit.",
+        "requirements":{  
+            "prereqs":[  
+
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"COMM 225",
+        "name":"Production and Operations Management",
+        "credits":"3",
+        "lectureHours":"three hours per week",
+        "description":"This course is an introduction to contemporary operational issues and techniques in the manufacturing and service sectors. Among the topics covered are operations strategy, forecasting, materials' management, total quality management, time-based competition, and minimal manufacturing. Mathematical modelling in resource allocation is also introduced. Cases and computer-aided quantitative tools for decision-making are used throughout the course with an emphasis on the interactions between production/operations management and other business disciplines.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "COMM 210"
+                ],
+                [  
+                    "COMM 212"
+                ],
+                [  
+                    "COMM 215"
+                ]
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"CART 211",
+        "name":"Creative Computing and Network Culture",
+        "credits":"3",
+        "lectureHours":"four hours per week",
+        "description":"This course gives a broad introduction to the fundamentals of creative computing and network culture. Through readings and practical examples, students explore the histories of the Internet, computing, and interactivity as well as gain knowledge of fundamental technical tools used for creating network-based media.",
+        "note":"Students who have received credit for DFAR 251 or CART 251 may not take this course for credit.",
+        "requirements":{  
+            "prereqs":[  
+
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"COMM 222",
+        "name":"Organizational Behaviour and Theory",
+        "credits":"3",
+        "lectureHours":"three hours per week",
+        "description":"This course is designed to provide students with an opportunity to study individual behaviour in formal organizations. Through theoretical case and experiential approaches, the focus of instruction progressively moves through individual, group and organizational levels of analysis. Topics in the course include perception, learning, personality, motivation, leadership, group behaviour, and organizational goals and structure.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "COMM 210"
+                ],
+                [  
+                    "COMM 212"
+                ]
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"CART 212",
+        "name":"Digital Media Studio I",
+        "credits":"3",
+        "lectureHours":"four hours per week",
+        "description":"This studio-based course focuses on the production of dynamic and interactive audio/visual media. Students develop proficiency in generating original audio and visual material as well as exposure to current digital media software. Concurrent with gaining knowledge of existing tools for production, students create a high-quality studio work for portfolio inclusion.",
+        "note":"Students who have received credit for DFAR 252 or CART 252 may not take this course for credit.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "CART 211"
+                ]
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"CART 411",
+        "name":"Project Studio I",
+        "credits":"3",
+        "lectureHours":"four hours per week",
+        "description":"In this studio and theory course, students integrate skills with objects, narratives, and environments. They refine both critical and practical management skills in team-based projects.",
+        "note":"Students who have received credit for CART 451 may not take this course for credit. Students in the Specialization in Computation Arts must complete CART 253.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "CART 253"
+                ],
+                [  
+                    "CART 351"
+                ]
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"ACCO 220",
+        "name":"Financial and Managerial Accounting",
+        "credits":"3",
+        "lectureHours":"three hours per week",
+        "description":"This course provides an introduction to accounting principles underlying the preparation of financial reports with an emphasis on the relationship between accounting information and production decisions. It examines the relationship between costs, production volume, and profit, as well as the practical benefits of standard costs for planning and control purposes. The role of accounting information in various manufacturing decisions is also highlighted.",
+        "note":"This course is useful for Engineering students. Students in or entering the B.Comm or B.Admin program will not receive credit for this course. JMSB students may not take this course for credit. Students who have received credit for ACCO 230, 240, COMM 217 or 305 may not take this course for credit.",
+        "requirements":{  
+            "prereqs":[  
+
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"COMM 223",
+        "name":"Marketing Management I",
+        "credits":"3",
+        "lectureHours":"three hours per week",
+        "description":"This survey course introduces students to the key concepts in marketing. Topics covered include marketing strategy, buyer behaviour, and the impact of technology on the discipline. The course also explores the important role that marketing plays in advancing society.",
+        "note":"Students who have received credit for COMM 224 or MARK 201 may not take this course for credit.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "COMM 210"
+                ]
+            ],
+            "coreqs":[  
+                [  
+                    "COMM 212"
+                ]
+            ]
+        }
+    },
+    {  
+        "code":"BLDG 471",
+        "name":"HVAC System Design",
+        "credits":"4",
+        "lectureHours":"three hours per week",
+        "labHours":"two hours per week",
+        "description":"Principles of HVAC system design and analysis; sustainable design issues and impact on environment; component and system selection criteria including room air distribution, fans and air circulation, humidifying and dehumidifying processes, piping and ducting design. Air quality standards. Control systems and techniques; operational economics; computer applications.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "BLDG 371"
+                ]
+            ],
+            "coreqs":[  
+                [  
+                    "BLDG 476"
+                ]
+            ]
+        }
+    },
+    {  
+        "code":"CART 351",
+        "name":"Networks and Navigation",
+        "credits":"3",
+        "lectureHours":"four hours per week",
+        "description":"In this studio course, students develop interactive projects that take advantage of networked data, redefine online communities, and experiment with new communication structures. The perceptual and aesthetic aspects of digital media are addressed in relation to the technical skill sets required for navigating and understanding the possibilities and limits of networked environments.",
+        "note":"Students in the Specialization in Computation Arts must complete CART 253.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "CART 211"
+                ],
+                [  
+                    "CART 212"
+                ],
+                [  
+                    "CART 253"
+                ]
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"CART 412",
+        "name":"Project Studio II",
+        "credits":"3",
+        "lectureHours":"four hours per week",
+        "description":"An advanced studio and theory course in which students integrate skills with objects, narratives, and environments. They refine both critical and practical management skills in team-based projects.",
+        "note":"Students who have received credit for CART 452 may not take this course for credit.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "CART 411"
+                ]
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"COMM 210",
+        "name":"Contemporary Business Thinking",
+        "credits":"3",
+        "lectureHours":"three hours per week",
+        "description":"This course presents a broad survey of the world of business and aims to incite students to develop a critical perspective on business literature. Students explore foundational business writings and evaluate the central ideas for scope, relevance, and managerial utility. The course also fosters students’ inclination to keep well informed about contemporary issues in organizations and business.",
+        "note":"It is recommended that part-time students complete this course, along with COMM 212, as early in their program as possible.",
+        "requirements":{  
+            "prereqs":[  
+
+            ],
+            "coreqs":[  
+                [  
+                    "COMM 212"
+                ],
+                [  
+                    "ECON 201",
+                    "ECON 203"
+                ]
+            ]
+        }
+    },
+    {  
+        "code":"COMM 308",
+        "name":"Introduction to Finance",
+        "credits":"3",
+        "lectureHours":"three hours per week",
+        "description":"This course provides a general understanding of the fundamental concepts of finance theory as they apply to the firm's long-run and short-run financing, and investment decisions. Building on the objective of firm value maximization, students become familiar with the conceptual issues underlying risk and return relationships and their measurements, as well as the valuation of financial securities. They also learn the concept of cost of capital, its measurement, and the techniques of capital budgeting as practised by today's managers. Students are introduced to the basic issues surrounding the firm's short-term and long-term funding decisions and its ability to pay dividends.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "COMM 217"
+                ]
+            ],
+            "coreqs":[  
+                [  
+                    "COMM 220"
+                ]
+            ]
+        }
+    },
+    {  
+        "code":"COEN 451",
+        "name":"VLSI Circuit Design",
+        "credits":"4",
+        "lectureHours":"three hours per week",
+        "description":"Analysis and design of electronic circuits using Very Large Scale Integration (VLSI) technologies. Physical design of MOS digital circuits. CMOS circuit schematic and layout. CMOS processing technology, design rules and CAD issues. Physical layers and parasitic elements of CMOS circuits. Characterization and performance evaluation. Constraints on speed, power dissipation and silicon space consumption. Design and implementation of CMOS logic structures, interconnections and I/O structures. Circuit design project using a specified CMOS technology.",
+        "note":"Students who have received credit for ENCS 454 may not take this course for credit. Laboratory: 30 hours total.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "COEN 212"
+                ],
+                [  
+                    "ELEC 311"
+                ]
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    },
+    {  
+        "code":"MECH 490",
+        "name":"CAPSTONE MECHANICAL ENGINEERING DESIGN PROJECT",
+        "credits":"4",
+        "lectureHours":"one hour per week",
+        "labHours":"three hours per week",
+        "description":"A supervised design, simulation or experimental capstone design project including a preliminary project proposal with complete project plan and a technical report at the end of the fall term; a final report by the group and presentation at the end of the winter term.",
+        "note":"Students will work in groups under direct supervision of a faculty member.",
+        "requirements":{  
+            "prereqs":[  
+                [  
+                    "ENCS 282"
+                ],
+                [  
+                    "ENGR 301"
+                ],
+                [  
+                    "MECH 344"
+                ],
+                [  
+                    "MECH 390"
+                ]
+            ],
+            "coreqs":[  
+
+            ]
+        }
+    }
+]

--- a/webscraping/courseInfo/storing/manualEntry.json
+++ b/webscraping/courseInfo/storing/manualEntry.json
@@ -1,335 +1,244 @@
-﻿[  
-    {  
-        "code":"FFAR 250",
-        "name":"Keywords: Reading the Arts Across the Disciplines",
-        "credits":"6",
-        "lectureHours":"three hours per week",
-        "description":"This course offers students with first-year standing in the Faculty of Fine Arts a broad introduction to ideas and aesthetics in the visual and performing arts in Canada. It focuses on key concepts shaping and shaped by artistic production and reception in all artistic disciplines. Students deepen their understanding of the cultural significance and the debate that occurs around keywords across the disciplines. Over the year, students extend their powers of reading, writing, and critical thinking in lectures and tutorials.",
-        "note":"This course is a BFA Degree requirement, and it is strongly recommended that students take it as part of their first year course selection.  The course will provide a wide ranging introduction to the visual and performing arts in the contemporary world. Emphasis will be placed on the interrelationships that exist among the arts, and the continuing impact of the past on the present. Much attention will be given to the contemporary arts in Canada and ever increasing cross-cultural awarenesses. Please note you MUST attend the lecture and tutorial in which you are registered.  All lectures will start the week of September 5, 2017.  Tutorials with a number (1) will meet for the first time the week of September 11, 2017, and every second week thereafter.  Tutorials with a number (2) will meet for the first time the week of September 18, 2017, and every second week thereafter. NOTE: The tutorial for this section will be taught in ENGLISH.",
-        "requirements":{  
-            "prereqs":[  
-
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"CART 255",
-        "name":"New Media Theory",
-        "credits":"3",
-        "lectureHours":"four hours per week",
-        "description":"This course is a critical introduction to new media theory focusing on issues of interaction, inscription, representation, code, reproduction, spectacle, control, body and resistance. Students develop tools to undertake a critical analysis of media and technology and their social, political, economic, and cultural ramifications.",
-        "requirements":{  
-            "prereqs":[  
-
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"CART 214",
-        "name":"A New Media Theory",
-        "credits":"3",
-        "lectureHours":"four hours per week",
-        "description":"Key themes of visual communication are explored in the context of computation arts. This studio course considers design elements such as line, pattern, shape, texture, interpretation of space, surface, perspective, dimension, repetition, randomness, colour and colour spaces, typography, drawing from observation, layout and composition and conceptualization. This class is predominantly non-digital and discusses the relationships between analog and digital approaches.",
-        "note":"Students who have received credit for CART 254 may not take this course for credit.",
-        "requirements":{  
-            "prereqs":[  
-
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"COMM 225",
-        "name":"Production and Operations Management",
-        "credits":"3",
-        "lectureHours":"three hours per week",
-        "description":"This course is an introduction to contemporary operational issues and techniques in the manufacturing and service sectors. Among the topics covered are operations strategy, forecasting, materials' management, total quality management, time-based competition, and minimal manufacturing. Mathematical modelling in resource allocation is also introduced. Cases and computer-aided quantitative tools for decision-making are used throughout the course with an emphasis on the interactions between production/operations management and other business disciplines.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "COMM 210"
-                ],
-                [  
-                    "COMM 212"
-                ],
-                [  
-                    "COMM 215"
-                ]
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"CART 211",
-        "name":"Creative Computing and Network Culture",
-        "credits":"3",
-        "lectureHours":"four hours per week",
-        "description":"This course gives a broad introduction to the fundamentals of creative computing and network culture. Through readings and practical examples, students explore the histories of the Internet, computing, and interactivity as well as gain knowledge of fundamental technical tools used for creating network-based media.",
-        "note":"Students who have received credit for DFAR 251 or CART 251 may not take this course for credit.",
-        "requirements":{  
-            "prereqs":[  
-
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"COMM 222",
-        "name":"Organizational Behaviour and Theory",
-        "credits":"3",
-        "lectureHours":"three hours per week",
-        "description":"This course is designed to provide students with an opportunity to study individual behaviour in formal organizations. Through theoretical case and experiential approaches, the focus of instruction progressively moves through individual, group and organizational levels of analysis. Topics in the course include perception, learning, personality, motivation, leadership, group behaviour, and organizational goals and structure.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "COMM 210"
-                ],
-                [  
-                    "COMM 212"
-                ]
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"CART 212",
-        "name":"Digital Media Studio I",
-        "credits":"3",
-        "lectureHours":"four hours per week",
-        "description":"This studio-based course focuses on the production of dynamic and interactive audio/visual media. Students develop proficiency in generating original audio and visual material as well as exposure to current digital media software. Concurrent with gaining knowledge of existing tools for production, students create a high-quality studio work for portfolio inclusion.",
-        "note":"Students who have received credit for DFAR 252 or CART 252 may not take this course for credit.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "CART 211"
-                ]
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"CART 411",
-        "name":"Project Studio I",
-        "credits":"3",
-        "lectureHours":"four hours per week",
-        "description":"In this studio and theory course, students integrate skills with objects, narratives, and environments. They refine both critical and practical management skills in team-based projects.",
-        "note":"Students who have received credit for CART 451 may not take this course for credit. Students in the Specialization in Computation Arts must complete CART 253.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "CART 253"
-                ],
-                [  
-                    "CART 351"
-                ]
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"ACCO 220",
-        "name":"Financial and Managerial Accounting",
-        "credits":"3",
-        "lectureHours":"three hours per week",
-        "description":"This course provides an introduction to accounting principles underlying the preparation of financial reports with an emphasis on the relationship between accounting information and production decisions. It examines the relationship between costs, production volume, and profit, as well as the practical benefits of standard costs for planning and control purposes. The role of accounting information in various manufacturing decisions is also highlighted.",
-        "note":"This course is useful for Engineering students. Students in or entering the B.Comm or B.Admin program will not receive credit for this course. JMSB students may not take this course for credit. Students who have received credit for ACCO 230, 240, COMM 217 or 305 may not take this course for credit.",
-        "requirements":{  
-            "prereqs":[  
-
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"COMM 223",
-        "name":"Marketing Management I",
-        "credits":"3",
-        "lectureHours":"three hours per week",
-        "description":"This survey course introduces students to the key concepts in marketing. Topics covered include marketing strategy, buyer behaviour, and the impact of technology on the discipline. The course also explores the important role that marketing plays in advancing society.",
-        "note":"Students who have received credit for COMM 224 or MARK 201 may not take this course for credit.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "COMM 210"
-                ]
-            ],
-            "coreqs":[  
-                [  
-                    "COMM 212"
-                ]
-            ]
-        }
-    },
-    {  
-        "code":"BLDG 471",
-        "name":"HVAC System Design",
-        "credits":"4",
-        "lectureHours":"three hours per week",
-        "labHours":"two hours per week",
-        "description":"Principles of HVAC system design and analysis; sustainable design issues and impact on environment; component and system selection criteria including room air distribution, fans and air circulation, humidifying and dehumidifying processes, piping and ducting design. Air quality standards. Control systems and techniques; operational economics; computer applications.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "BLDG 371"
-                ]
-            ],
-            "coreqs":[  
-                [  
-                    "BLDG 476"
-                ]
-            ]
-        }
-    },
-    {  
-        "code":"CART 351",
-        "name":"Networks and Navigation",
-        "credits":"3",
-        "lectureHours":"four hours per week",
-        "description":"In this studio course, students develop interactive projects that take advantage of networked data, redefine online communities, and experiment with new communication structures. The perceptual and aesthetic aspects of digital media are addressed in relation to the technical skill sets required for navigating and understanding the possibilities and limits of networked environments.",
-        "note":"Students in the Specialization in Computation Arts must complete CART 253.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "CART 211"
-                ],
-                [  
-                    "CART 212"
-                ],
-                [  
-                    "CART 253"
-                ]
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"CART 412",
-        "name":"Project Studio II",
-        "credits":"3",
-        "lectureHours":"four hours per week",
-        "description":"An advanced studio and theory course in which students integrate skills with objects, narratives, and environments. They refine both critical and practical management skills in team-based projects.",
-        "note":"Students who have received credit for CART 452 may not take this course for credit.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "CART 411"
-                ]
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"COMM 210",
-        "name":"Contemporary Business Thinking",
-        "credits":"3",
-        "lectureHours":"three hours per week",
-        "description":"This course presents a broad survey of the world of business and aims to incite students to develop a critical perspective on business literature. Students explore foundational business writings and evaluate the central ideas for scope, relevance, and managerial utility. The course also fosters students’ inclination to keep well informed about contemporary issues in organizations and business.",
-        "note":"It is recommended that part-time students complete this course, along with COMM 212, as early in their program as possible.",
-        "requirements":{  
-            "prereqs":[  
-
-            ],
-            "coreqs":[  
-                [  
-                    "COMM 212"
-                ],
-                [  
-                    "ECON 201",
-                    "ECON 203"
-                ]
-            ]
-        }
-    },
-    {  
-        "code":"COMM 308",
-        "name":"Introduction to Finance",
-        "credits":"3",
-        "lectureHours":"three hours per week",
-        "description":"This course provides a general understanding of the fundamental concepts of finance theory as they apply to the firm's long-run and short-run financing, and investment decisions. Building on the objective of firm value maximization, students become familiar with the conceptual issues underlying risk and return relationships and their measurements, as well as the valuation of financial securities. They also learn the concept of cost of capital, its measurement, and the techniques of capital budgeting as practised by today's managers. Students are introduced to the basic issues surrounding the firm's short-term and long-term funding decisions and its ability to pay dividends.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "COMM 217"
-                ]
-            ],
-            "coreqs":[  
-                [  
-                    "COMM 220"
-                ]
-            ]
-        }
-    },
-    {  
-        "code":"COEN 451",
-        "name":"VLSI Circuit Design",
-        "credits":"4",
-        "lectureHours":"three hours per week",
-        "description":"Analysis and design of electronic circuits using Very Large Scale Integration (VLSI) technologies. Physical design of MOS digital circuits. CMOS circuit schematic and layout. CMOS processing technology, design rules and CAD issues. Physical layers and parasitic elements of CMOS circuits. Characterization and performance evaluation. Constraints on speed, power dissipation and silicon space consumption. Design and implementation of CMOS logic structures, interconnections and I/O structures. Circuit design project using a specified CMOS technology.",
-        "note":"Students who have received credit for ENCS 454 may not take this course for credit. Laboratory: 30 hours total.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "COEN 212"
-                ],
-                [  
-                    "ELEC 311"
-                ]
-            ],
-            "coreqs":[  
-
-            ]
-        }
-    },
-    {  
-        "code":"MECH 490",
-        "name":"CAPSTONE MECHANICAL ENGINEERING DESIGN PROJECT",
-        "credits":"4",
-        "lectureHours":"one hour per week",
-        "labHours":"three hours per week",
-        "description":"A supervised design, simulation or experimental capstone design project including a preliminary project proposal with complete project plan and a technical report at the end of the fall term; a final report by the group and presentation at the end of the winter term.",
-        "note":"Students will work in groups under direct supervision of a faculty member.",
-        "requirements":{  
-            "prereqs":[  
-                [  
-                    "ENCS 282"
-                ],
-                [  
-                    "ENGR 301"
-                ],
-                [  
-                    "MECH 344"
-                ],
-                [  
-                    "MECH 390"
-                ]
-            ],
-            "coreqs":[  
-
-            ]
-        }
+[
+  {
+    "code": "FFAR 250",
+    "name": "Keywords: Reading the Arts Across the Disciplines",
+    "credits": "6",
+    "lectureHours": "three hours per week",
+    "description": "This course offers students with first-year standing in the Faculty of Fine Arts a broad introduction to ideas and aesthetics in the visual and performing arts in Canada. It focuses on key concepts shaping and shaped by artistic production and reception in all artistic disciplines. Students deepen their understanding of the cultural significance and the debate that occurs around keywords across the disciplines. Over the year, students extend their powers of reading, writing, and critical thinking in lectures and tutorials.",
+    "note": "This course is a BFA Degree requirement, and it is strongly recommended that students take it as part of their first year course selection.  The course will provide a wide ranging introduction to the visual and performing arts in the contemporary world. Emphasis will be placed on the interrelationships that exist among the arts, and the continuing impact of the past on the present. Much attention will be given to the contemporary arts in Canada and ever increasing cross-cultural awarenesses. Please note you MUST attend the lecture and tutorial in which you are registered.  All lectures will start the week of September 5, 2017.  Tutorials with a number (1) will meet for the first time the week of September 11, 2017, and every second week thereafter.  Tutorials with a number (2) will meet for the first time the week of September 18, 2017, and every second week thereafter. NOTE: The tutorial for this section will be taught in ENGLISH.",
+    "requirements": {
+      "prereqs": [],
+      "coreqs": []
     }
+  },
+  {
+    "code": "CART 255",
+    "name": "New Media Theory",
+    "credits": "3",
+    "lectureHours": "four hours per week",
+    "description": "This course is a critical introduction to new media theory focusing on issues of interaction, inscription, representation, code, reproduction, spectacle, control, body and resistance. Students develop tools to undertake a critical analysis of media and technology and their social, political, economic, and cultural ramifications.",
+    "requirements": {
+      "prereqs": [],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "CART 214",
+    "name": "A New Media Theory",
+    "credits": "3",
+    "lectureHours": "four hours per week",
+    "description": "Key themes of visual communication are explored in the context of computation arts. This studio course considers design elements such as line, pattern, shape, texture, interpretation of space, surface, perspective, dimension, repetition, randomness, colour and colour spaces, typography, drawing from observation, layout and composition and conceptualization. This class is predominantly non-digital and discusses the relationships between analog and digital approaches.",
+    "note": "Students who have received credit for CART 254 may not take this course for credit.",
+    "requirements": {
+      "prereqs": [],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "COMM 225",
+    "name": "Production and Operations Management",
+    "credits": "3",
+    "lectureHours": "three hours per week",
+    "description": "This course is an introduction to contemporary operational issues and techniques in the manufacturing and service sectors. Among the topics covered are operations strategy, forecasting, materials' management, total quality management, time-based competition, and minimal manufacturing. Mathematical modelling in resource allocation is also introduced. Cases and computer-aided quantitative tools for decision-making are used throughout the course with an emphasis on the interactions between production/operations management and other business disciplines.",
+    "requirements": {
+      "prereqs": [
+        ["COMM 210"],
+        ["COMM 212"],
+        ["COMM 215"]
+      ],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "CART 211",
+    "name": "Creative Computing and Network Culture",
+    "credits": "3",
+    "lectureHours": "four hours per week",
+    "description": "This course gives a broad introduction to the fundamentals of creative computing and network culture. Through readings and practical examples, students explore the histories of the Internet, computing, and interactivity as well as gain knowledge of fundamental technical tools used for creating network-based media.",
+    "note": "Students who have received credit for DFAR 251 or CART 251 may not take this course for credit.",
+    "requirements": {
+      "prereqs": [],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "COMM 222",
+    "name": "Organizational Behaviour and Theory",
+    "credits": "3",
+    "lectureHours": "three hours per week",
+    "description": "This course is designed to provide students with an opportunity to study individual behaviour in formal organizations. Through theoretical case and experiential approaches, the focus of instruction progressively moves through individual, group and organizational levels of analysis. Topics in the course include perception, learning, personality, motivation, leadership, group behaviour, and organizational goals and structure.",
+    "requirements": {
+      "prereqs": [
+        ["COMM 210"],
+        ["COMM 212"]
+      ],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "CART 212",
+    "name": "Digital Media Studio I",
+    "credits": "3",
+    "lectureHours": "four hours per week",
+    "description": "This studio-based course focuses on the production of dynamic and interactive audio/visual media. Students develop proficiency in generating original audio and visual material as well as exposure to current digital media software. Concurrent with gaining knowledge of existing tools for production, students create a high-quality studio work for portfolio inclusion.",
+    "note": "Students who have received credit for DFAR 252 or CART 252 may not take this course for credit.",
+    "requirements": {
+      "prereqs": [
+        ["CART 211"]
+      ],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "CART 411",
+    "name": "Project Studio I",
+    "credits": "3",
+    "lectureHours": "four hours per week",
+    "description": "In this studio and theory course, students integrate skills with objects, narratives, and environments. They refine both critical and practical management skills in team-based projects.",
+    "note": "Students who have received credit for CART 451 may not take this course for credit. Students in the Specialization in Computation Arts must complete CART 253.",
+    "requirements": {
+      "prereqs": [
+        ["CART 253"],
+        ["CART 351"]
+      ],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "ACCO 220",
+    "name": "Financial and Managerial Accounting",
+    "credits": "3",
+    "lectureHours": "three hours per week",
+    "description": "This course provides an introduction to accounting principles underlying the preparation of financial reports with an emphasis on the relationship between accounting information and production decisions. It examines the relationship between costs, production volume, and profit, as well as the practical benefits of standard costs for planning and control purposes. The role of accounting information in various manufacturing decisions is also highlighted.",
+    "note": "This course is useful for Engineering students. Students in or entering the B.Comm or B.Admin program will not receive credit for this course. JMSB students may not take this course for credit. Students who have received credit for ACCO 230, 240, COMM 217 or 305 may not take this course for credit.",
+    "requirements": {
+      "prereqs": [],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "COMM 223",
+    "name": "Marketing Management I",
+    "credits": "3",
+    "lectureHours": "three hours per week",
+    "description": "This survey course introduces students to the key concepts in marketing. Topics covered include marketing strategy, buyer behaviour, and the impact of technology on the discipline. The course also explores the important role that marketing plays in advancing society.",
+    "note": "Students who have received credit for COMM 224 or MARK 201 may not take this course for credit.",
+    "requirements": {
+      "prereqs": [
+        ["COMM 210"]
+      ],
+      "coreqs": [
+        ["COMM 212"]
+      ]
+    }
+  },
+  {
+    "code": "BLDG 471",
+    "name": "HVAC System Design",
+    "credits": "4",
+    "lectureHours": "three hours per week",
+    "labHours": "two hours per week",
+    "description": "Principles of HVAC system design and analysis; sustainable design issues and impact on environment; component and system selection criteria including room air distribution, fans and air circulation, humidifying and dehumidifying processes, piping and ducting design. Air quality standards. Control systems and techniques; operational economics; computer applications.",
+    "requirements": {
+      "prereqs": [
+        ["BLDG 371"]
+      ],
+      "coreqs": [
+        ["BLDG 476"]
+      ]
+    }
+  },
+  {
+    "code": "CART 351",
+    "name": "Networks and Navigation",
+    "credits": "3",
+    "lectureHours": "four hours per week",
+    "description": "In this studio course, students develop interactive projects that take advantage of networked data, redefine online communities, and experiment with new communication structures. The perceptual and aesthetic aspects of digital media are addressed in relation to the technical skill sets required for navigating and understanding the possibilities and limits of networked environments.",
+    "note": "Students in the Specialization in Computation Arts must complete CART 253.",
+    "requirements": {
+      "prereqs": [
+        ["CART 211"],
+        ["CART 212"],
+        ["CART 253"]
+      ],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "CART 412",
+    "name": "Project Studio II",
+    "credits": "3",
+    "lectureHours": "four hours per week",
+    "description": "An advanced studio and theory course in which students integrate skills with objects, narratives, and environments. They refine both critical and practical management skills in team-based projects.",
+    "note": "Students who have received credit for CART 452 may not take this course for credit.",
+    "requirements": {
+      "prereqs": [
+        ["CART 411"]
+      ],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "COMM 210",
+    "name": "Contemporary Business Thinking",
+    "credits": "3",
+    "lectureHours": "three hours per week",
+    "description": "This course presents a broad survey of the world of business and aims to incite students to develop a critical perspective on business literature. Students explore foundational business writings and evaluate the central ideas for scope, relevance, and managerial utility. The course also fosters students’ inclination to keep well informed about contemporary issues in organizations and business.",
+    "note": "It is recommended that part-time students complete this course, along with COMM 212, as early in their program as possible.",
+    "requirements": {
+      "prereqs": [],
+      "coreqs": [
+        ["COMM 212"],
+        ["ECON 201", "ECON 203"]
+      ]
+    }
+  },
+  {
+    "code": "COMM 308",
+    "name": "Introduction to Finance",
+    "credits": "3",
+    "lectureHours": "three hours per week",
+    "description": "This course provides a general understanding of the fundamental concepts of finance theory as they apply to the firm's long-run and short-run financing, and investment decisions. Building on the objective of firm value maximization, students become familiar with the conceptual issues underlying risk and return relationships and their measurements, as well as the valuation of financial securities. They also learn the concept of cost of capital, its measurement, and the techniques of capital budgeting as practised by today's managers. Students are introduced to the basic issues surrounding the firm's short-term and long-term funding decisions and its ability to pay dividends.",
+    "requirements": {
+      "prereqs": [
+        ["COMM 217"]
+      ],
+      "coreqs": [
+        ["COMM 220"]
+      ]
+    }
+  },
+  {
+    "code": "COEN 451",
+    "name": "VLSI Circuit Design",
+    "credits": "4",
+    "lectureHours": "three hours per week",
+    "description": "Analysis and design of electronic circuits using Very Large Scale Integration (VLSI) technologies. Physical design of MOS digital circuits. CMOS circuit schematic and layout. CMOS processing technology, design rules and CAD issues. Physical layers and parasitic elements of CMOS circuits. Characterization and performance evaluation. Constraints on speed, power dissipation and silicon space consumption. Design and implementation of CMOS logic structures, interconnections and I/O structures. Circuit design project using a specified CMOS technology.",
+    "note": "Students who have received credit for ENCS 454 may not take this course for credit. Laboratory: 30 hours total.",
+    "requirements": {
+      "prereqs": [
+        ["COEN 212"],
+        ["ELEC 311"]
+      ],
+      "coreqs": []
+    }
+  },
+  {
+    "code": "MECH 490",
+    "name": "CAPSTONE MECHANICAL ENGINEERING DESIGN PROJECT",
+    "credits": "4",
+    "lectureHours": "one hour per week",
+    "labHours": "three hours per week",
+    "description": "A supervised design, simulation or experimental capstone design project including a preliminary project proposal with complete project plan and a technical report at the end of the fall term; a final report by the group and presentation at the end of the winter term.",
+    "note": "Students will work in groups under direct supervision of a faculty member.",
+    "requirements": {
+      "prereqs": [
+        ["ENCS 282"],
+        ["ENGR 301"],
+        ["MECH 344"],
+        ["MECH 390"]
+      ],
+      "coreqs": []
+    }
+  }
 ]


### PR DESCRIPTION
# I DID THE SLAVE WORK 🥇 

related to issue #86 

## Summary

Please read the new document I added: [missingCoursesNotes.md](https://github.com/stumash/CoursePlanner/blob/c33d4e14fccec28bb213bbbbc82c30b56617eb06/docs/missingCoursesNotes.md) before continuing. It's really short. The markdown turned out kinda ugly so maybe its better to just view it as plain text when u read it.

To completely fix the issue described in #86, we must accomplish two things on the webscraping level:

1. Remove ENGR 417 from the sequence(s) it's contained in.
2. Rename the remainder of the missing courses listed in `missingCoursesNotes.md` to their true counterpart.

## Test

Try to run missingCourses.js and you should only get the courses I documented as problematic in  `missingCoursesNotes.md`.

---

*j a u r a i*
*f o k i n*
*b e s o i n*