### PR TITLE
Add touch support for drag-n-drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "browserify": "^14.4.0",
     "bundle-collapser": "^1.2.1",
     "envify": "^4.1.0",
-    "uglify-js": "^3.0.25",
-    "uglifyify": "3.0.4",
+    "react": "^15.6.1",
     "react-dnd": "^2.4.0",
-    "react-dnd-html5-backend": "^2.4.1"
+    "react-dnd-html5-backend": "^2.4.1",
+    "react-dnd-touch-backend": "^0.3.15",
+    "react-dom": "^15.6.1",
+    "uglify-js": "^3.0.25",
+    "uglifyify": "3.0.4"
   }
 }

--- a/src/main/webapp/babel-src/course.js
+++ b/src/main/webapp/babel-src/course.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { DragSource } from 'react-dnd';
-import { ITEM_TYPES, renderCourseDiv, dragSource, collectSource } from "./util";
+import { ITEM_TYPES, renderCourseDiv, courseDragSource, collectSource } from "./util";
 
 /*
  *  Box which represents one single course;  can be made draggable vis isDraggable.
@@ -45,4 +45,4 @@ class Course extends React.Component {
     }
 }
 
-export default DragSource(ITEM_TYPES.COURSE, dragSource, collectSource)(Course);
+export default DragSource(ITEM_TYPES.COURSE, courseDragSource, collectSource)(Course);

--- a/src/main/webapp/babel-src/courseDragPreview.js
+++ b/src/main/webapp/babel-src/courseDragPreview.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { DragLayer } from 'react-dnd';
+import { ITEM_TYPES, renderCourseDiv,renderOrListDiv } from "./util";
+
+
+function collect(monitor){
+    return {
+        item: monitor.getItem(),
+        itemType: monitor.getItemType(),
+        initialOffset: monitor.getInitialSourceClientOffset(),
+        currentOffset: monitor.getSourceClientOffset(),
+        isDragging: monitor.isDragging()
+    }
+}
+
+const layerStyles = {
+    position: 'fixed',
+    pointerEvents: 'none',
+    zIndex: 100,
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%'
+};
+
+function getItemStyles(props) {
+    const { currentOffset } = props;
+    if (!currentOffset) {
+        return {
+            display: 'none'
+        };
+    }
+
+    const { x, y } = currentOffset;
+    const transform = `translate(${x}px, ${y}px)`;
+    return {
+        transform: transform,
+        WebkitTransform: transform
+    };
+}
+
+class CourseDragPreview extends React.Component {
+
+    renderItem(type, item) {
+        switch (type) {
+            case ITEM_TYPES.COURSE:
+                return (
+                    renderCourseDiv(item.courseObj, " dragPreview")
+                );
+            case ITEM_TYPES.OR_LIST:
+                return (
+                    renderOrListDiv(item.courseList, " dragPreview")
+                );
+            default:
+                return "Default Drag Preview";
+        }
+    }
+
+    render() {
+        if (!this.props.isDragging) {
+            return null;
+        }
+
+        return (
+            <div style={layerStyles}>
+                <div style={getItemStyles(this.props)}>
+                    {this.renderItem(this.props.itemType, this.props.item)}
+                </div>
+            </div>
+        );
+    }
+}
+
+export default DragLayer(collect)(CourseDragPreview);

--- a/src/main/webapp/babel-src/dragPreview.js
+++ b/src/main/webapp/babel-src/dragPreview.js
@@ -39,7 +39,7 @@ function getItemStyles(props) {
     };
 }
 
-class CourseDragPreview extends React.Component {
+class DragPreview extends React.Component {
 
     renderItem(type, item) {
         switch (type) {
@@ -71,4 +71,4 @@ class CourseDragPreview extends React.Component {
     }
 }
 
-export default DragLayer(collect)(CourseDragPreview);
+export default DragLayer(collect)(DragPreview);

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -1,12 +1,15 @@
 import React from "react";
 
-import HTML5Backend from 'react-dnd-html5-backend';
+// import TouchBackend from 'react-dnd-html5-backend';
+import { default as TouchBackend } from 'react-dnd-touch-backend';
 import { DragDropContext } from 'react-dnd';
 
 import {SemesterTable} from "./semesterTable";
 import {SemesterList} from "./semesterList";
 import {IOPanel} from "./ioPanel";
+import CourseDragPreview from "./courseDragPreview";
 import {DEFAULT_PROGRAM, saveAs, generateUniqueKey, generateUniqueKeys} from "./util";
+
 
 /*
  *  Root component of our main page
@@ -27,7 +30,8 @@ class MainPage extends React.Component {
             "allSequences" : [],
             "selectedCourseInfo" : {},
             "loadingExport": false,
-            "showingGarbage": false
+            "showingGarbage": false,
+            "allowingTextSelection": true
         };
 
         // functions that are passed as callbacks need to be bound to current class - see https://facebook.github.io/react/docs/handling-events.html
@@ -40,11 +44,43 @@ class MainPage extends React.Component {
         this.moveCourse = this.moveCourse.bind(this);
         this.addCourse = this.addCourse.bind(this);
         this.removeCourse = this.removeCourse.bind(this);
+        this.changeDragState = this.changeDragState.bind(this);
+        this.enableTextSelection = this.enableTextSelection.bind(this);
     }
 
     componentDidMount() {
         this.loadCourseSequenceObject();
         this.loadAllSequences();
+    }
+
+    /*
+     *  function to call when the users starts or stops dragging any item
+     *      param isDragging - true if the user is dragging something
+     */
+    changeDragState(isDragging){
+        this.enableTextSelection(!isDragging);
+        this.enableGarbage(isDragging);
+    }
+
+    /*
+     *  function to call to disable text selection on the page
+     *  it is used to fix an issue in firefox where text on the page gets highlighted while dragging a course
+     *      param enabled - should the garbage can be enabled
+     */
+    enableTextSelection(enabled){
+        this.setState({
+            "allowingTextSelection": enabled
+        });
+    }
+
+    /*
+     *  function to call when we want to display the garbage can and allow the user to delete a course
+     *      param enabled - should the garbage can be enabled
+     */
+    enableGarbage(enabled){
+        this.setState({
+            "showingGarbage": enabled
+        });
     }
 
     /*
@@ -194,8 +230,9 @@ class MainPage extends React.Component {
     }
 
     render() {
+
         return (
-            <div className="row">
+            <div className={"row" + (this.state.allowingTextSelection ? "" : " textSelectionOff")}>
                 <div className="col-md-3 col-sm-12">
                     <IOPanel courseInfo={this.state.selectedCourseInfo}
                              allSequences={this.state.allSequences}
@@ -215,7 +252,7 @@ class MainPage extends React.Component {
                                    onToggleWorkTerm={this.toggleWorkTerm}
                                    onMoveCourse={this.moveCourse}
                                    onAddCourse={this.addCourse}
-                                   onChangeDragState={this.enableGarbage}/>
+                                   onChangeDragState={this.changeDragState}/>
                 </div>
                 <div className="col-xs-8 col-xs-offset-2 hidden-md hidden-lg">
                     <SemesterList courseSequenceObject={this.state.courseSequenceObject}
@@ -224,8 +261,9 @@ class MainPage extends React.Component {
                                   onToggleWorkTerm={this.toggleWorkTerm}
                                   onMoveCourse={this.moveCourse}
                                   onAddCourse={this.addCourse}
-                                  onChangeDragState={this.enableGarbage}/>
+                                  onChangeDragState={this.changeDragState}/>
                 </div>
+                <CourseDragPreview/>
             </div>
         );
     }
@@ -325,4 +363,4 @@ class MainPage extends React.Component {
     }
 }
 
-export default DragDropContext(HTML5Backend)(MainPage);
+export default DragDropContext(TouchBackend({enableMouseEvents: true}))(MainPage);

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -244,7 +244,12 @@ class MainPage extends React.Component {
     handleMouseMove(mouseMoveEvent){
         this.performAutoScroll(mouseMoveEvent.clientY, mouseMoveEvent.view.innerHeight);
     }
-    
+
+    /*
+     *  function which decides whether or not the page should scroll based on the position of the user's cursor
+     *      param y - number indicating the y coordinate of the user's cursor, where the top of the page is y = 0
+     *      param pageHeight - number indicating the total height of the page in pixels
+     */
     performAutoScroll(y, pageHeight){
       if(this.isDragging) {
         let scrollAreaHeight = pageHeight * AUTO_SCROLL_PAGE_PORTION;
@@ -273,7 +278,10 @@ class MainPage extends React.Component {
         this.shouldScroll = false;
       }
     }
-    
+
+    /*
+     *  recursive function which continuously scrolls up or down the page until this.shouldScroll becomes false
+     */
     scrollPage(){
         setTimeout(() => {
             window.scrollBy(0, this.scrollDirection * AUTO_SCROLL_STEP);
@@ -284,7 +292,6 @@ class MainPage extends React.Component {
     }
 
     render() {
-
         return (
             <div className={"row" + (this.state.allowingTextSelection ? "" : " textSelectionOff")} onMouseMove={this.handleMouseMove} onTouchMove={this.handleTouchMove}>
                 <div className="col-md-3 col-sm-12">

--- a/src/main/webapp/babel-src/orList.js
+++ b/src/main/webapp/babel-src/orList.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { DragSource } from 'react-dnd';
-import { UI_STRINGS, ITEM_TYPES, renderCourseDiv, dragSource, collectSource } from "./util";
+import { UI_STRINGS, ITEM_TYPES, renderOrListDiv, orListDragSource, collectSource } from "./util";
 
 /*
  *  Box which represents a list of courses where one may be selected;  can be made draggable vis isDraggable.
@@ -27,22 +27,6 @@ class OrList extends React.Component {
         super(props);
     }
 
-    renderSelectedOrCourse(){
-
-        let selectedCourse = undefined;
-        let selectedIndex = -1;
-
-        this.props.courseList.forEach((courseObj, orListIndex) => {
-            if(courseObj.isSelected){
-                selectedCourse = courseObj;
-                selectedIndex = orListIndex;
-            }
-        });
-
-        return (!selectedCourse) ? <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP}>{UI_STRINGS.LIST_NONE_SELECTED}</div> :
-                                   renderCourseDiv(selectedCourse, "", () => this.props.onCourseClick(selectedCourse.code));
-    }
-
     render() {
 
         let extraClassNames = " ";
@@ -56,33 +40,8 @@ class OrList extends React.Component {
         let courseList = this.props.courseList;
         let position = this.props.position;
 
-        return this.props.connectDragSource(
-            <div className={"orList input-group" + extraClassNames}>
-                <div className="input-group-btn">
-                    <button className="btn btn-default dropdown-toggle" title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP} type="button"  data-toggle="dropdown">
-                        <span className="caret"></span>
-                    </button>
-                    <ul className="dropdown-menu">
-                        {courseList.map((courseObj, courseIndex) =>
-                            <li key={courseObj.id}>
-                                {renderCourseDiv(courseObj, "", () => {
-                                    this.props.onOrListSelection({
-                                        "yearIndex": position.yearIndex,
-                                        "season": position.season,
-                                        "courseListIndex": position.courseListIndex,
-                                        "orListIndex": courseIndex
-                                    });
-                                })}
-                            </li>
-                        )}
-                    </ul>
-                </div>
-                <div className="input-group-addon">
-                    {this.renderSelectedOrCourse()}
-                </div>
-            </div>
-        );
+        return this.props.connectDragSource(renderOrListDiv(courseList, extraClassNames, position, this.props.onCourseClick, this.props.onOrListSelection));
     }
 }
 
-export default DragSource(ITEM_TYPES.OR_LIST, dragSource, collectSource)(OrList);
+export default DragSource(ITEM_TYPES.OR_LIST, orListDragSource, collectSource)(OrList);

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -46,13 +46,34 @@ export const UI_STRINGS = {
 /*
  *  Special object used by react-dnd to register a drag source
  */
-export const dragSource = {
+export const courseDragSource = {
     beginDrag(props, monitor, component) {
 
         props.onChangeDragState && props.onChangeDragState(true);
 
         return {
             "courseObj": props.courseObj,
+            "position": props.position
+        };
+    },
+    endDrag(props, monitor, component){
+        props.onChangeDragState && props.onChangeDragState(false);
+    },
+    canDrag(props, monitor){
+        return props.isDraggable;
+    }
+};
+
+/*
+ *  Special object used by react-dnd to register a drag source
+ */
+export const orListDragSource = {
+    beginDrag(props, monitor, component) {
+
+        props.onChangeDragState && props.onChangeDragState(true);
+
+        return {
+            "courseList": props.courseList,
             "position": props.position
         };
     },
@@ -124,6 +145,37 @@ export function generateUniqueKey(courseObj, season, yearIndex, courseListIndex,
 }
 
 
+
+export function renderOrListDiv(courseList, extraClassNames, position, clickHandler, listClickHandler){
+    return (
+        <div className={"orList input-group" + extraClassNames}>
+            <div className="input-group-btn">
+                <button className="btn btn-default dropdown-toggle" title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP} type="button"  data-toggle="dropdown">
+                    <span className="caret"></span>
+                </button>
+                <ul className="dropdown-menu">
+                    {courseList.map((courseObj, courseIndex) =>
+                        <li key={courseObj.id}>
+                            {renderCourseDiv(courseObj, "", () => {
+                                listClickHandler({
+                                    "yearIndex": position.yearIndex,
+                                    "season": position.season,
+                                    "courseListIndex": position.courseListIndex,
+                                    "orListIndex": courseIndex
+                                });
+                            })}
+                        </li>
+                    )}
+                </ul>
+            </div>
+            <div className="input-group-addon">
+                {renderSelectedOrCourse(courseList, clickHandler)}
+            </div>
+        </div>
+    );
+}
+
+
 /*
  *  Render a div which represents a course.
  *      extraClassNames: string which contains a list of class names separated by spaces
@@ -139,4 +191,27 @@ export function renderCourseDiv(courseObj, extraClassNames, clickHandler){
             </div>
         </div>
     );
+}
+
+function renderSelectedOrCourse(courseList, clickHandler){
+
+    let selectedCourse = undefined;
+    let selectedIndex = -1;
+
+    courseList.forEach((courseObj, orListIndex) => {
+        if(courseObj.isSelected){
+            selectedCourse = courseObj;
+            selectedIndex = orListIndex;
+        }
+    });
+
+    return (!selectedCourse) ? <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP}>{UI_STRINGS.LIST_NONE_SELECTED}</div> :
+        renderCourseDiv(selectedCourse, "", () => clickHandler(selectedCourse.code));
+}
+
+function scrollDownForever() {
+    setTimeout(function(){
+        window.scrollBy(0, 1);
+        scrollDownForever();
+    }, 33);
 }

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -6,10 +6,14 @@
  */
 import React from "react";
 
+// Regular old constants
 export const SEASON_NAMES_PRETTY = ["Fall", "Winter", "Summer"];
 export const SEASON_NAMES = SEASON_NAMES_PRETTY.map((season) => season.toLowerCase());
 export const DEFAULT_PROGRAM = "SOEN-General-Coop";
 export const EXPORT_TYPES = ["PDF", "MD", "TXT"];
+export const AUTO_SCROLL_PAGE_PORTION = 0.1; // auto scroll on the top and bottom 10% of screen
+export const AUTO_SCROLL_STEP = 10;
+export const AUTO_SCROLL_DELAY = 20;
 
 // Item types used for DND
 export const ITEM_TYPES = {

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -99,8 +99,10 @@ export function collectSource(connect, monitor) {
     };
 }
 
-// convenience function that allows you to save the file contained at location uri to disk of client machine
-// currently used for downloading exported PDF file
+/*
+ *  Convenience function that allows you to save the file contained at location uri to disk of client machine
+ *  currently used for downloading exported PDF file
+ */
 export function saveAs(uri, filename) {
     var link = document.createElement('a');
     if (typeof link.download === 'string') {
@@ -148,8 +150,10 @@ export function generateUniqueKey(courseObj, season, yearIndex, courseListIndex,
     return id;
 }
 
-
-
+/*
+ *  Render a div which represents an orList of courses.
+ *      extraClassNames: string with a leading space which contains a list of class names separated by spaces
+ */
 export function renderOrListDiv(courseList, extraClassNames, position, clickHandler, listClickHandler){
     return (
         <div className={"orList input-group" + extraClassNames}>
@@ -210,12 +214,5 @@ function renderSelectedOrCourse(courseList, clickHandler){
     });
 
     return (!selectedCourse) ? <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP}>{UI_STRINGS.LIST_NONE_SELECTED}</div> :
-        renderCourseDiv(selectedCourse, "", () => clickHandler(selectedCourse.code));
-}
-
-function scrollDownForever() {
-    setTimeout(function(){
-        window.scrollBy(0, 1);
-        scrollDownForever();
-    }, 33);
+                               renderCourseDiv(selectedCourse, "", () => clickHandler(selectedCourse.code));
 }

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -2,6 +2,10 @@
 
 /* Root styling */
 
+html, body, #react-root, #react-root > div {
+    height: 100%;
+}
+
 #react-root {
     padding-top: 15px;
     font-size: 14px;
@@ -223,8 +227,8 @@ ul.ui-autocomplete {
 @media (max-width: 991px) {
 
     #react-root,
-    .semesterList .orList .input-group-addon,
-    .semesterList .orList .dropdown-menu,
+    #react-root .orList .input-group-addon,
+    #react-root .orList .dropdown-menu,
     .ioPanel .export button,
     .ioPanel .export .dropdown-menu,
     .ioPanel .programSelect select,
@@ -241,34 +245,53 @@ ul.ui-autocomplete {
         height: 48px;
     }
 
-    .semesterList .course,
-    .semesterList .orList,
-    .semesterList .orList .dropdown-menu .course,
+    .course,
+    #react-root .orList,
+    #react-root .orList .dropdown-menu .course,
     .ioPanel .course {
         width: 300px;
     }
 
-    .semesterList div:not(.input-group-addon) > .course,
-    .semesterList .orList,
-    .semesterList .orList button,
-    .semesterList .orList .dropdown-menu .course,
+    #react-root div:not(.input-group-addon) > .course,
+    #react-root .orList,
+    #react-root .orList button,
+    #react-root .orList .dropdown-menu .course,
     .ioPanel .course{
         height: 66px;
     }
+    #react-root .orList button {
+        width: 35px;
+    }
 
-    .semesterList div:not(.input-group-addon) > .course,
-    .semesterList .orList .dropdown-menu .course,
+    #react-root div:not(.input-group-addon) > .course,
+    #react-root .orList .dropdown-menu .course,
     .ioPanel .course{
         padding-top: 12px;
     }
 
-    .semesterList .orList .input-group-addon .course {
+    #react-root .orList .input-group-addon .course {
         height: 64px;
         padding-top: 18px;
     }
 
-    .semesterList input[type="checkbox"] {
+    #react-root input[type="checkbox"] {
         height: 30px;
         width: 30px;
     }
+}
+
+/* Special styling for DND */
+
+.dragPreview {
+    margin: 0;
+}
+
+.textSelectionOff {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: -moz-none;
+    -ms-user-select: none;
+    -o-user-select: none;
+    user-select: none;
 }

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -2,10 +2,6 @@
 
 /* Root styling */
 
-html, body, #react-root, #react-root > div {
-    height: 100%;
-}
-
 #react-root {
     padding-top: 15px;
     font-size: 14px;


### PR DESCRIPTION
resolves #99 

## Summary

- Added support for touch screens using the method discussed in #99. 
- Added the ability to auto-scroll when you drag a course to the top or bottom of the page. There are libraries for accomplishing this but they weren't working when I tested them so I decided to code this functionality from scratch. The code for it ended up being pretty simple anyways.

## Test

The changes are up on http://conucourseplanner.online/courseplannerj/. Please test with any touch screen device you have. Make sure to try dragging the course to the bottom or top of the screen and make sure the screen auto-scrolls.