### PR TITLE
Add course correction map

### DIFF
--- a/webscraping/courseSequences/scraping/courseCorrectionMap.json
+++ b/webscraping/courseSequences/scraping/courseCorrectionMap.json
@@ -1,0 +1,10 @@
+{
+  "ENGR 418": "AERO 483",
+  "COMP 393": "ENCS 393",
+  "ELEC 415": "AERO 480",
+  "ELEC 416": "AERO 482",
+  "MAST 224": "MAST 324",
+  "ENGR 417": "",
+  "MECH 480": "AERO 480",
+  "MECH 482": "AERO 482"
+}


### PR DESCRIPTION
resolves #86 

## Summary

As discussed in PR #111, I have added a new file `courseCorrectionMap.json` which gets used by the sequence scraper to fix the fact that we didn't have the courseInfo for some courses contained in our scraped sequences.

For each course code key in the map, the scraper swaps all occurrences of that code in each sequence with the key's value. If the key's value is an empty string, it removes the course altogether.

## Test

Run `scrapeTheWeb.sh` then run `missingCourses.js` and it should output: 
```
There are no courses that are listed in at least one recommended sequence but are not present in the course info DB
```