### PR TITLE
Improve backend memory usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.0</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
             </plugin>
 
             <!-- Tomcat packager -->
@@ -57,9 +61,11 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
         </dependency>
+
 
         <dependency>
             <groupId>log4j</groupId>

--- a/src/main/java/CPServlet.java
+++ b/src/main/java/CPServlet.java
@@ -24,7 +24,7 @@ public abstract class CPServlet extends HttpServlet {
         // set up the logger
         logger = Logger.getLogger(getServletName());
 
-        // get reference to application-wide mongoclient provided by Servlet Context
+        // get reference to application-wide app properties provided by Servlet Context
         appProperties = (Properties) config.getServletContext().getAttribute("APP_PROPERTIES");
     }
 

--- a/src/main/java/CPServlet.java
+++ b/src/main/java/CPServlet.java
@@ -1,17 +1,14 @@
-import org.apache.log4j.LogManager;
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.apache.commons.io.IOUtils;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Properties;
 
@@ -27,21 +24,13 @@ public abstract class CPServlet extends HttpServlet {
         // set up the logger
         logger = Logger.getLogger(getServletName());
 
-        // load the app properties
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        InputStream input = classLoader.getResourceAsStream("courseplanner.properties");
-        appProperties = new Properties();
-        try{
-            appProperties.load(input);
-        } catch(IOException e){
-            logger.error("Error getting webapp properties");
-            throw new ServletException(e);
-        }
+        // get reference to application-wide mongoclient provided by Servlet Context
+        appProperties = (Properties) config.getServletContext().getAttribute("APP_PROPERTIES");
     }
 
     JSONObject getRequestJson(HttpServletRequest request) throws IOException{
         JSONObject requestJson;
-	String requestString = IOUtils.toString(request.getReader());
+        String requestString = IOUtils.toString(request.getReader());
         try {
             logger.info("raw request String:");
             logger.info(requestString);
@@ -86,10 +75,5 @@ public abstract class CPServlet extends HttpServlet {
         }
 
         return semesters;
-    }
-
-    public void destroy() {
-        LogManager.shutdown();
-        super.destroy();
     }
 }

--- a/src/main/java/DBServlet.java
+++ b/src/main/java/DBServlet.java
@@ -1,5 +1,4 @@
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
@@ -13,8 +12,8 @@ public abstract class DBServlet extends CPServlet {
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
 
-        // set up references to mongo collections
-        MongoClient mongoClient = new MongoClient(new MongoClientURI(appProperties.getProperty("mongoUrl")));
+        // get reference to application-wide mongoclient provided by Servlet Context
+        MongoClient mongoClient = (MongoClient) config.getServletContext().getAttribute("MONGO_CLIENT");
         MongoDatabase db = mongoClient.getDatabase(getDbName());
         courseData = db.getCollection(appProperties.getProperty("courseDataCollectionName"));
         courseSequences = db.getCollection(appProperties.getProperty("courseSequenceCollectionName"));

--- a/src/main/java/MongoDBContextListener.java
+++ b/src/main/java/MongoDBContextListener.java
@@ -46,8 +46,8 @@ public class MongoDBContextListener implements ServletContextListener {
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
-        MongoClient mongo = (MongoClient) sce.getServletContext().getAttribute("MONGO_CLIENT");
-        mongo.close();
+        MongoClient mongoClient = (MongoClient) sce.getServletContext().getAttribute("MONGO_CLIENT");
+        mongoClient.close();
         logger.info("MongoClient closed successfully");
         LogManager.shutdown();
     }

--- a/src/main/java/MongoDBContextListener.java
+++ b/src/main/java/MongoDBContextListener.java
@@ -1,0 +1,54 @@
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+@WebListener
+public class MongoDBContextListener implements ServletContextListener {
+
+    private Logger logger;
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+
+        logger = Logger.getLogger(sce.getServletContext().getServletContextName());
+
+        // load the app properties
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        InputStream input = classLoader.getResourceAsStream("courseplanner.properties");
+        Properties appProperties = new Properties();
+        try{
+            appProperties.load(input);
+        } catch(IOException e){
+            String message = "Error reading courseplanner.properties";
+            logger.error(message);
+            throw new RuntimeException(message);
+        }
+
+        // add the app properties to the servlet context
+        sce.getServletContext().setAttribute("APP_PROPERTIES", appProperties);
+
+        // create a mongo client
+        MongoClient mongoClient = new MongoClient(new MongoClientURI(appProperties.getProperty("mongoUrl")));
+        logger.info("MongoClient initialized successfully");
+
+        // add the mongo client to the servlet context
+        sce.getServletContext().setAttribute("MONGO_CLIENT", mongoClient);
+
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        MongoClient mongo = (MongoClient) sce.getServletContext().getAttribute("MONGO_CLIENT");
+        mongo.close();
+        logger.info("MongoClient closed successfully");
+        LogManager.shutdown();
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -11,6 +11,10 @@
         <location>/404.html</location>
     </error-page>
 
+    <listener>
+        <listener-class>MongoDBContextListener</listener-class>
+    </listener>
+
     <servlet>
         <servlet-name>SequenceValidator</servlet-name>
         <servlet-class>SequenceValidator</servlet-class>


### PR DESCRIPTION
## Summary

### The problem

I've been noticing lately that our tomcat server has been shutting down unexpectedly due to an OutOfMemoryError. So I set up memory profiling with a program called yourkit and I noticed that every time a request is made to a servlet which does any db operations (a.k.a `DBServlet`), the memory usage of the application would increase by like 300kb and this memory would not get freed up over time/by garbage collection. I haven't been able to directly reproduce the OutOfMemoryError but I assume it is related to this issue. 

### The solution

I checked out the type of java objects that were making up the majority of this extra memory usage and it was mostly HashMaps used under the hood by MongoDB (see screenshot below). This led me to re-read the [mongodb docs](http://mongodb.github.io/mongo-java-driver/3.4/driver/getting-started/quick-start/) where I found that the normal usage is to create only one MongoClient object instance to be reused by all servlets in your application. This is different from what we're currently doing which is creating a unique MongoClient object for each servlet. I followed a [guide](https://www.journaldev.com/4011/mongodb-java-servlet-web-application-example-tutorial) on how to share a single reference to a MongoClient object accross all servlets and I made the necessary changes.

The version of java we have running on our server is 1.7 so I configured our maven build to use the same version. Also, to be able to use annotations in our backend code I needed to bump up the version of the `javax.servlet` library from `2.5` to `3.1.0`

After this, I found that the problem of memory being used then not freed up on every db request went away. If we ever end up getting an OutOfMemoryError again, I've configured the JVM to do a memory dump when that occurs, in which case we can take a look at what's taking up the most memory in the application.

![image](https://user-images.githubusercontent.com/2389735/31321538-c28ee646-ac55-11e7-89ed-a52a837a326f.png)

## Java memory profiling

If you want to try out the memory profiling yourself, you can profile our server remotely by installing yourkit and clicking `Connect to remote application` then for the hostname put `conucourseplanner.online`.