### PR TITLE
Renamed courseData to courseInfo accross project

### DIFF
--- a/src/main/java/CourseInfoProvider.java
+++ b/src/main/java/CourseInfoProvider.java
@@ -31,7 +31,7 @@ public class CourseInfoProvider extends DBServlet {
         // find document with specified _id value
         Document filter = new Document();
         filter.put("_id", courseCode);
-        Document dbResult = (Document) courseData.find(filter).first();
+        Document dbResult = (Document) courseInfo.find(filter).first();
 
         if(dbResult != null) {
             return dbResult.toJson();

--- a/src/main/java/DBServlet.java
+++ b/src/main/java/DBServlet.java
@@ -7,7 +7,7 @@ import javax.servlet.ServletException;
 
 public abstract class DBServlet extends CPServlet {
 
-    protected MongoCollection courseData, courseSequences;
+    protected MongoCollection courseInfo, courseSequences;
 
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
@@ -15,7 +15,7 @@ public abstract class DBServlet extends CPServlet {
         // get reference to application-wide mongoclient provided by Servlet Context
         MongoClient mongoClient = (MongoClient) config.getServletContext().getAttribute("MONGO_CLIENT");
         MongoDatabase db = mongoClient.getDatabase(getDbName());
-        courseData = db.getCollection(appProperties.getProperty("courseDataCollectionName"));
+        courseInfo = db.getCollection(appProperties.getProperty("courseInfoCollectionName"));
         courseSequences = db.getCollection(appProperties.getProperty("courseSequenceCollectionName"));
     }
 

--- a/src/main/java/FilterCourseCodes.java
+++ b/src/main/java/FilterCourseCodes.java
@@ -31,7 +31,7 @@ public class FilterCourseCodes extends DBServlet {
         CourseCodeBlock resultsProcessor = new CourseCodeBlock();
 
         filter.put("_id", regex);
-        courseData.find(filter).limit(MAX_RESULTS).forEach(resultsProcessor);
+        courseInfo.find(filter).limit(MAX_RESULTS).forEach(resultsProcessor);
 
         responseString = resultsProcessor.getResults();
 

--- a/src/main/java/SequenceProvider.java
+++ b/src/main/java/SequenceProvider.java
@@ -105,7 +105,7 @@ public class SequenceProvider extends DBServlet {
 
             Document filter = new Document();
             filter.put("_id", courseObject.getString("code"));
-            Document dbResult = (Document) courseData.find(filter).first();
+            Document dbResult = (Document) courseInfo.find(filter).first();
 
 	    if(dbResult == null){
 		logger.info("got null db result for course: " + courseObject.getString("code"));

--- a/src/main/resources/courseplanner.properties
+++ b/src/main/resources/courseplanner.properties
@@ -3,7 +3,7 @@ buildType = ${buildType}
 dbNameDev = courseplannerdb-dev
 dbNameProd = courseplannerdb
 mongoUrl = mongodb://username:password@conucourseplanner.online:27017/?authSource=admin
-courseDataCollectionName = courseData
+courseInfoCollectionName = courseInfo
 courseSequenceCollectionName = courseSequences
 
 exportsDirectory = exports

--- a/webscraping/courseInfo/storing/storer.js
+++ b/webscraping/courseInfo/storing/storer.js
@@ -67,7 +67,7 @@ const storeAllCourseInfo = (function (){
 
                         // write the json to the db
                         courseInfosJSON.forEach(courseInfoJSON => {
-                            db.collection("courseData").update({_id : courseInfoJSON.code}, {$set:courseInfoJSON}, {upsert: true}, function(err, result) {
+                            db.collection("courseInfo").update({_id : courseInfoJSON.code}, {$set:courseInfoJSON}, {upsert: true}, function(err, result) {
                                 assert.equal(err, null);
                                 logMessage("Wrote contents of file: " + courseInfoJSON.code + " to db.")
                             })

--- a/webscraping/courseSequences/storing/missingCourses.js
+++ b/webscraping/courseSequences/storing/missingCourses.js
@@ -13,7 +13,7 @@ const dbName = (argv.prod) ? prodDbName : devDbName;
 const dbFullUrl = f('mongodb://%s:%s@conucourseplanner.online:27017/%s?authSource=admin', username, password, dbName);
 
 const courseSequencesColName = "courseSequences";
-const courseInfoColName = "courseData";
+const courseInfoColName = "courseInfo";
 
 let displayMissingCourses = (() => {
     MongoClient.connect(dbFullUrl, (err, db) => {


### PR DESCRIPTION
resolves #117 

## Summary

- Renamed `courseData` db collection in the code and ran the webscraper to add the new `courseInfo` collection to the db

- Needed to heighten the permissions of user tranzoneAdmin in the mongo shell to allow dropping databases, listing collections, etc:
```
> use admin
switched to db admin
> db.grantRolesToUser("tranzoneAdmin", [ {role: "dbOwner", db: "courseplannerdb-dev"} ])
> db.grantRolesToUser("tranzoneAdmin", [ {role: "dbOwner", db: "courseplannerdb"} ])
```

## Test

I tested the webscraper and the backend (no changes made to frontend) and it was all working. Don't worry about et.

## After merging

Since PR #120 is still open for testing, I actually left the `courseData` collection in both the dev and prod DBs. Once this PR is merged, I will remove the collection from both DBs. Currently the dev DB has both `courseData` and `courseInfo`, and they are identical:
```
> use courseplannerdb-dev
switched to db courseplannerdb-dev
> show collections
courseData
courseInfo
courseSequences
> db.getCollection("courseData").find({}).size();
2128
> db.getCollection("courseInfo").find({}).size();
2128
```