### PR TITLE
Added Google Analytics Global Site Tag to main page

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-108808524-1"></script>
+	<script>
+  	    window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-108808524-1');
+        </script>
         <meta charset="utf-8">
         <title>ConU Course Planner</title>
 


### PR DESCRIPTION
resolves #52 

## Summary

All I did was add a little snippet to `index.html` which lets google analytics do its magic. I haven't looked too hard into it but I assume that's all we have to do to get the base set of analytics features, which is probably as much as we'll ever need.

The google analytics "account" is registered under the email that we use to send emails within our webscraper (concordiacourseplanner@gmail.com). I added the personal emails of myself, @stumash,  and @PeterGhimself to have full access to our analytics page (Manage Users, Edit, Collaborate, Read & Analyze). As such, you guys should have received and email about it and should be able to access the analytics home page at https://analytics.google.com. 