### PR TITLE
updated cronSample.txt with new VM cron job

### DIFF
--- a/docs/CronSample.txt
+++ b/docs/CronSample.txt
@@ -2,6 +2,6 @@ Adding the following line to the crontab would result in the production database
 
 0 0 * * * sh /opt/cp-webscraping/scrapeTheWeb.sh "$(< /home/david/tranzoneAdminPass.txt)" --prod
 
-Adding the following line to the crontab would result in the production exports folder getting cleaned (delete files older than 2h) every 2h
+Adding the following line to the crontab would result in the production exports folder getting cleaned (delete files older than 2h) every hour
 
-0 */2 * * * find /opt/tomcat/webapps/ROOT/exports/* -mmin +120 -exec rm -f {} \;
+0 * * * * find /opt/tomcat/webapps/ROOT/exports/* -mmin +120 -exec rm -f {} \;

--- a/docs/CronSample.txt
+++ b/docs/CronSample.txt
@@ -1,3 +1,7 @@
 Adding the following line to the crontab would result in the production database getting updated once every 24 hours.
 
-0 0 * * * sh /opt/cp-webscraping/scrapeTheWeb.sh --prod
+0 0 * * * sh /opt/cp-webscraping/scrapeTheWeb.sh "$(< /home/david/tranzoneAdminPass.txt)" --prod
+
+Adding the following line to the crontab would result in the production exports folder getting cleaned (delete files older than 2h) every 2h
+
+0 */2 * * * find /opt/tomcat/webapps/ROOT/exports/* -mmin +120 -exec rm -f {} \;

--- a/webscraping/scrapeTheWeb.sh
+++ b/webscraping/scrapeTheWeb.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # This is our script for running our webscraping activites. It it to be run in a cron script.
-# Example: 0 0 * * * sh /home/david/CoursePlanner/webscraping/scrapeTheWeb.sh
 
 pushd `dirname $0` > /dev/null
 webscrapedir=$(pwd)


### PR DESCRIPTION
resolves #129 

## Summary

First, I decided to move our current cron job (webscraping) to the root crontab instead of david's crontab, so

`sudo crontab -e` instead of  `crontab -e`

Then, I added the new exports-folder-clearing cronjob to the crontab. So now, both of the jobs listed in CronSample.txt are officially running on our VM.

Note that only the production exports folder is cleared periodically, not our personal web apps'.