### PR TITLE
Add table export option

### DIFF
--- a/docs/apiSamples/exportRequestSample.json
+++ b/docs/apiSamples/exportRequestSample.json
@@ -1,4 +1,6 @@
 {
+  "exportType": "list", 
+  "programName": "Software Engineering",
   "courseSequenceObject":{
     "yearList":[
       {

--- a/docs/sequenceTableSample.html
+++ b/docs/sequenceTableSample.html
@@ -18,7 +18,7 @@
                 border: 1px solid black;
                 text-align: center;
             }
-            h2 {
+            h2, h3 {
                 text-align: center;
             }
             p {
@@ -31,6 +31,7 @@
     </head>
     <body>
         <h2>My Proposed Sequence</h2>
+        <h3>Software Engineering, General Program Option, Coop September Entry (120 credits)</h3>
         <table>
             <thead>
                 <tr>

--- a/docs/sequenceTableSample.html
+++ b/docs/sequenceTableSample.html
@@ -31,7 +31,8 @@
     </head>
     <body>
         <h2>My Proposed Sequence</h2>
-        <h3>Software Engineering, General Program Option, Coop September Entry (120 credits)</h3>
+        <h3>Software Engineering</h3>
+
         <table>
             <thead>
                 <tr>
@@ -45,120 +46,38 @@
                 <tr>
                     <td>Year 1</td>
                     <td>
-                        (Work Term)
                         <ol>
                             <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
+                            <li>ENGR 201</li>
+                        </ol>
+                    </td>
+                    <td>
+                        <ol>
+                            <li>COMP 249</li>
+                            <li>Science Elective</li>
                         </ol>
                     </td>
                     <td>
                         (Work Term)
-        
-                    </td>
-                    <td>
-                        <ol>
-        
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
+                        <br/>No Courses
                     </td>
                 </tr>
                 <tr>
                     <td>Year 2</td>
                     <td>
-                        <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
+                        <br/>No Courses
                     </td>
                     <td>
                         <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
+                            <li>SOEN 490</li>
+                            <li>COMP 345</li>
                         </ol>
                     </td>
                     <td>
-                        <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
+                        <br/>No Courses
                     </td>
                 </tr>
-                <tr>
-                    <td>Year 3</td>
-                    <td>
-                        <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
-                    </td>
-                    <td>
-                        <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
-                    </td>
-                    <td>
-                        <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Year 4</td>
-                    <td>
-                        <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
-                    </td>
-                    <td>
-                        <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
-                    </td>
-                    <td>
-                        <ol>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                            <li>COMP 248</li>
-                        </ol>
-                    </td>
-                </tr>
+
             </tbody>
         </table>
         <p>Approved by: ____________________________________________</p>

--- a/docs/sequenceTableSample.html
+++ b/docs/sequenceTableSample.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <style>
+            table {
+                font-size: 20px;
+                width: 100%;
+                border: 1px solid black;
+                border-collapse: collapse;
+            }
+            tr > td:first-of-type {
+                font-weight: bold;
+            }
+            ol {
+                padding-left: 40px;
+            }
+            td, th {
+                border: 1px solid black;
+                text-align: center;
+            }
+            h2 {
+                text-align: center;
+            }
+            p {
+                font-size: 20px;
+                font-weight: bold;
+                text-align: center;
+                padding: 6px;
+            }
+        </style>
+    </head>
+    <body>
+        <h2>My Proposed Sequence</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th></th>
+                    <th>Fall</th>
+                    <th>Winter</th>
+                    <th>Summer</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Year 1</td>
+                    <td>
+                        (Work Term)
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                    <td>
+                        (Work Term)
+        
+                    </td>
+                    <td>
+                        <ol>
+        
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Year 2</td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Year 3</td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Year 4</td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                    <td>
+                        <ol>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                            <li>COMP 248</li>
+                        </ol>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <p>Approved by: ____________________________________________</p>
+        <p>Signature:____________________________&nbsp;&nbsp;Date: ______________</p>
+    </body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,7 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
-
-
+        
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
@@ -85,7 +84,7 @@
             <version>3.4.2</version>
         </dependency>
 
-	<dependency>
+	    <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.5</version>

--- a/src/main/java/CPServlet.java
+++ b/src/main/java/CPServlet.java
@@ -32,9 +32,6 @@ public abstract class CPServlet extends HttpServlet {
         JSONObject requestJson;
         String requestString = IOUtils.toString(request.getReader());
         try {
-            logger.info("raw request String:");
-            logger.info(requestString);
-            logger.info("end raw request String");
             requestJson =  new JSONObject(requestString);
         } catch (JSONException e) {
             e.printStackTrace();

--- a/src/main/java/SequenceExporter.java
+++ b/src/main/java/SequenceExporter.java
@@ -10,6 +10,15 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.nio.charset.Charset;
 
+/* 
+* Exports a courseSequenceObject to pdf. Supports two formats: table and list
+* 
+* For table: servlet will produce two downloadable files: one html and one pdf
+* For list: servlet will produce two downloadable files: one markdown and one pdf
+* 
+* responds with the relative path of the generated pdf file
+* 
+* */
 public class SequenceExporter extends CPServlet {
 
     private String EXPORTS_DIR;

--- a/src/main/java/SequenceExporter.java
+++ b/src/main/java/SequenceExporter.java
@@ -1,3 +1,4 @@
+import org.apache.commons.io.FileUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -7,10 +8,16 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
+import java.nio.charset.Charset;
 
 public class SequenceExporter extends CPServlet {
 
     private String EXPORTS_DIR;
+
+    private final String EXPORT_TYPE_LIST = "list";
+    private final String EXPORT_TYPE_TABLE = "table";
+    private final String LINE_ENDING = "\r\n";
+    private final String TAB = "    ";
 
     public void init(ServletConfig config) throws ServletException{
         super.init(config);
@@ -21,44 +28,120 @@ public class SequenceExporter extends CPServlet {
     {
         logger.info("---------User requested a sequence export---------");
 
-        JSONObject courseSequenceObject = (JSONObject) grabPropertyFromRequest("courseSequenceObject", request);
-
+        JSONObject requestObject = getRequestJson(request);
         JSONObject responseObject = new JSONObject();
-        try{
-
+        
+        try {
+            JSONObject courseSequenceObject = requestObject.getJSONObject("courseSequenceObject");
+            String exportType = requestObject.getString("exportType");
             JSONArray yearList = courseSequenceObject.getJSONArray("yearList");
+            
+            String fileName = generateFileName();
+            boolean exportSucceeded = false;
 
-            String semesterAsMarkdown = yearListToMarkdownString(yearList);
+            if(exportType.equals(EXPORT_TYPE_LIST)){
+                exportSucceeded = exportToList(fileName, yearList);
+            } else if(exportType.equals(EXPORT_TYPE_TABLE)){
+                exportSucceeded = exportToTable(fileName, yearList);
+            }
 
-            logger.info("Generated the following markdown:");
-
-            logger.info(semesterAsMarkdown);
-
-            //create a funky-unique filename in case of multiple users trying to export at once
-            long time = System.currentTimeMillis();
-            long threadId = Thread.currentThread().getId();
-            String fileName = time + "-" + threadId;
-
-            generatePDF(semesterAsMarkdown, fileName);
-
-            responseObject.put("exportPath",appProperties.getProperty("exportsDirectory")+"/"+fileName+".pdf");
-
+            if(exportSucceeded){
+                logger.info("Export succeeded");
+                responseObject.put("exportPath",appProperties.getProperty("exportsDirectory")+"/"+fileName+".pdf");
+            } else {
+                logger.info("Export failed");
+                responseObject.put("error", "Error exporting sequence");
+            }
         } catch (JSONException e) {
             logger.error(e.toString());
-            throw new IOException("Encountered JSON error when trying to export");
+            throw new IOException("Encountered JSON error when trying to export sequence");
         }
 
         PrintWriter out = response.getWriter();
-
         logger.info("Responding with: " + responseObject.toString());
         out.println(responseObject.toString());
     }
+
+    //create a unique filename for each exported file
+    private String generateFileName(){
+        long time = System.currentTimeMillis();
+        long threadId = Thread.currentThread().getId();
+        return time + "-" + threadId;
+    }
+
+    private boolean exportToTable(String fileName, JSONArray yearList) throws JSONException, IOException {
+
+        String semesterAsHtml = yearListToHtmlString(yearList);
+        String filePathNoExtension = EXPORTS_DIR + fileName;
+        String commandString = "wkhtmltopdf " + filePathNoExtension + ".html " + filePathNoExtension + ".pdf";
+
+        return writeFile(filePathNoExtension + ".html", semesterAsHtml) && runCommand(commandString);
+    }
+
+    private boolean exportToList(String fileName, JSONArray yearList) throws JSONException {
+
+        String semesterAsMarkdown = yearListToMarkdownString(yearList);
+        String filePathNoExtension = EXPORTS_DIR + fileName;
+        String commandString = "pandoc " + filePathNoExtension + ".md -o " + filePathNoExtension + ".pdf";
+
+        return writeFile(filePathNoExtension + ".md", semesterAsMarkdown) && runCommand(commandString);
+    }
+
+    // returns true if write succeeded
+    private boolean writeFile(String fullFilePath, String fileContent){
+        File outputFile = new File(fullFilePath);
+        try {
+            if(!outputFile.exists()){
+                outputFile.createNewFile();
+            }
+            PrintWriter out = new PrintWriter(outputFile);
+            out.println(fileContent);
+            out.close();
+        } catch (FileNotFoundException e) {
+            logger.error("File not found: " + fullFilePath);
+            e.printStackTrace();
+            return false;
+        } catch (IOException e) {
+            logger.error("IO Exception while writing to file: " + fullFilePath);
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+
+    // return true if command succeeded
+    private boolean runCommand(String commandString){
+        logger.info("executing command: " + commandString);
+        int exitCode = -1;
+        try {
+            Process proc = Runtime.getRuntime().exec(commandString);
+            BufferedReader read = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+            try {
+                proc.waitFor();
+                exitCode = proc.exitValue();
+            } catch (InterruptedException e) {
+                logger.error("Interrupted Exception while running command: " + commandString);
+                e.printStackTrace();
+                return false;
+            }
+            while (read.ready()) {
+                logger.info("Command output:" + read.readLine());
+            }
+        } catch (IOException e) {
+            logger.error("IO Exception while running command: " + commandString);
+            e.printStackTrace();
+            return false;
+        }
+        return exitCode == 0;
+    }
+    
+    /* Beefy StringBuilder functions */
 
     private String yearListToMarkdownString(JSONArray yearList) throws JSONException {
 
         StringBuilder builder = new StringBuilder();
 
-        builder.append("# My Course Sequence\r\n\r\n");
+        builder.append("# My Proposed Sequence" + LINE_ENDING + LINE_ENDING);
 
         for (int yearIndex = 0; yearIndex < yearList.length(); yearIndex++) {
 
@@ -74,10 +157,10 @@ public class SequenceExporter extends CPServlet {
 
                 String prettySeason = ((season.charAt(0) + "").toUpperCase()) + season.substring(1);
 
-                builder.append("### " + prettySeason + " " + (yearIndex + 1) + ((isWorkTerm) ? " (Work Term)" : "") + "\r\n\r\n");
+                builder.append("### " + prettySeason + " " + (yearIndex + 1) + ((isWorkTerm) ? " (Work Term)" : "") + LINE_ENDING + LINE_ENDING);
 
                 if (courseList.length() == 0) {
-                    builder.append("- No Courses\r\n");
+                    builder.append("- No Courses" + LINE_ENDING);
                 }
 
                 // loop through course list and fill missing info for each course
@@ -88,7 +171,7 @@ public class SequenceExporter extends CPServlet {
                     if (entry instanceof JSONObject) {
 
                         // found a simple course
-                        builder.append(courseObjectToString((JSONObject) entry));
+                        builder.append(courseObjectToMarkdown((JSONObject) entry));
 
                     } else if (entry instanceof JSONArray) {
 
@@ -99,74 +182,130 @@ public class SequenceExporter extends CPServlet {
                             JSONObject course = (JSONObject) orList.get(j);
                             boolean isSelected = course.has("isSelected") && course.getBoolean("isSelected");
                             if (isSelected) {
-                                builder.append(courseObjectToString(course));
+                                builder.append(courseObjectToMarkdown(course));
                             }
                         }
                     } else {
                         logger.warn("Found unusual value inside course sequence. Expected a course object but found: " + entry.toString());
                     }
                 }
-                builder.append("\r\n");
+                builder.append(LINE_ENDING);
             }
         }
         return builder.toString();
     }
 
-    private String courseObjectToString(JSONObject course) throws JSONException{
+    // replace {tableRows} in html template with generated html rows
+    private String yearListToHtmlString(JSONArray yearList) throws JSONException, IOException {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        File sequenceTableFile = new File(classLoader.getResource("sequenceTableTemplate.html").getFile());
+        String sequenceTableTemplateAsString = FileUtils.readFileToString(sequenceTableFile, Charset.defaultCharset());
+        return sequenceTableTemplateAsString.replace("{tableRows}", yearListToHtmlRows(yearList));
+    }
+    
+    private String yearListToHtmlRows(JSONArray yearList) throws JSONException {
+
+        StringBuilder builder = new StringBuilder();
+
+        for (int yearIndex = 0; yearIndex < yearList.length(); yearIndex++) {
+
+            JSONObject year = yearList.getJSONObject(yearIndex);
+
+            String[] seasons = {"fall", "winter", "summer"};
+
+            indent(builder, 4);
+            builder.append("<tr>" + LINE_ENDING);
+
+            indent(builder, 5);
+            builder.append("<td>Year " + (yearIndex + 1) + "</td>" + LINE_ENDING);
+
+            for (String season : seasons) {
+
+                JSONObject semester = year.getJSONObject(season);
+                JSONArray courseList = semester.getJSONArray("courseList");
+                boolean isWorkTerm = semester.getBoolean("isWorkTerm");
+
+                indent(builder, 5);
+                builder.append("<td>" + LINE_ENDING);
+
+                if(isWorkTerm){
+                    indent(builder, 6);
+                    builder.append("(Work Term)" + LINE_ENDING);
+                }
+
+                if (courseList.length() == 0) {
+                    indent(builder, 6);
+                    builder.append("<br/>No Courses" + LINE_ENDING);
+                } else {
+                    indent(builder, 6);
+                    builder.append("<ol>" + LINE_ENDING);
+                }
+
+                // loop through course list and fill missing info for each course
+                for (int i = 0; i < courseList.length(); i++) {
+
+                    Object entry = courseList.get(i);
+
+                    if (entry instanceof JSONObject) {
+
+                        // found a simple course
+                        JSONObject course = (JSONObject) entry;
+                        indent(builder, 7);
+                        builder.append("<li>" + courseObjectToHtml(course) + "</li>" + LINE_ENDING);
+
+                    } else if (entry instanceof JSONArray) {
+
+                        // found a list of courses (OR)
+                        JSONArray orList = (JSONArray) entry;
+
+                        for (int j = 0; j < orList.length(); j++) {
+                            JSONObject course = (JSONObject) orList.get(j);
+                            boolean isSelected = course.has("isSelected") && course.getBoolean("isSelected");
+                            if (isSelected) {
+                                indent(builder, 7);
+                                builder.append("<li>" + courseObjectToHtml(course) + "</li>" + LINE_ENDING);
+                            }
+                        }
+                    } else {
+                        logger.warn("Found unusual value inside course sequence. Expected a course object but found: " + entry.toString());
+                    }
+                }
+
+                if(courseList.length() > 0){
+                    indent(builder, 6);
+                    builder.append("</ol>" + LINE_ENDING);
+                }
+                indent(builder, 5);
+                builder.append("</td>" + LINE_ENDING);
+            }
+            indent(builder, 4);
+            builder.append("</tr>" + LINE_ENDING);
+        }
+        return builder.toString();
+    }
+
+    // used to indent the html so that the raw text is easier to read
+    private void indent(StringBuilder builder, int times) {
+        for(int i = 0; i < times; i++){
+            builder.append(TAB);
+        }
+    }
+
+    // representation of a course in markdown list
+    private String courseObjectToMarkdown(JSONObject course) throws JSONException{
         if(course.getBoolean("isElective")){
-            return ("- " + course.getString("electiveType") + " Elective\r\n");
+            return ("- " + course.getString("electiveType") + " Elective" + LINE_ENDING);
         } else {
-            return ("- " + course.getString("code") + ", " + course.getString("name") + ", " + course.getString("credits") + " Credits\r\n");
+            return ("- " + course.getString("code") + ", " + course.getString("name") + ", " + course.getString("credits") + " Credits" + LINE_ENDING);
         }
     }
 
-    // generate a pdf file in EXPORTS_DIR folder with name {fileName}.pdf
-    private String generatePDF(String markdownString, String fileName) {
-
-        // First, we write the markdown string to a .md file
-        File outputFile = new File(EXPORTS_DIR + fileName + ".md");
-        try {
-            if(!outputFile.exists()){
-                outputFile.createNewFile();
-            }
-            PrintWriter out = new PrintWriter(outputFile);
-            out.println(markdownString);
-            out.close();
-        } catch (FileNotFoundException e) {
-            logger.error("File not found");
-            e.printStackTrace();
-        } catch (IOException e) {
-            logger.error("IO Exception while writing to markdown file");
-            e.printStackTrace();
-        }
-
-        //Second, we run pandoc on that .md file to generate a .pdf
-        runPandoc(fileName);
-
-        return fileName;
-    }
-
-    private void runPandoc(String fileName){
-
-        String filePath = EXPORTS_DIR + fileName;
-        String commandString = "pandoc " + filePath + ".md -o " + filePath + ".pdf";
-        logger.info("executing command: " + commandString);
-
-        try {
-            Process proc = Runtime.getRuntime().exec(commandString);
-            BufferedReader read = new BufferedReader(new InputStreamReader(proc.getInputStream()));
-            try {
-                proc.waitFor();
-            } catch (InterruptedException e) {
-                logger.error("Interrupted Exception");
-                e.printStackTrace();
-            }
-            while (read.ready()) {
-                logger.warn("Pandoc output:" + read.readLine());
-            }
-        } catch (IOException e) {
-            logger.error("IO Exception while running pandoc");
-            e.printStackTrace();
+    // representation of a course in html table
+    private String courseObjectToHtml(JSONObject course) throws JSONException{
+        if(course.getBoolean("isElective")){
+            return (course.getString("electiveType") + " Elective");
+        } else {
+            return (course.getString("code"));
         }
     }
 }

--- a/src/main/resources/sequenceTableTemplate.html
+++ b/src/main/resources/sequenceTableTemplate.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <style>
+            table {
+                font-size: 20px;
+                width: 100%;
+                border: 1px solid black;
+                border-collapse: collapse;
+            }
+            tr > td:first-of-type {
+                font-weight: bold;
+            }
+            ol {
+                padding-left: 40px;
+            }
+            td, th {
+                border: 1px solid black;
+                text-align: center;
+            }
+            h2 {
+                text-align: center;
+            }
+            p {
+                font-size: 20px;
+                font-weight: bold;
+                text-align: center;
+                padding: 6px;
+            }
+        </style>
+    </head>
+    <body>
+        <h2>My Proposed Sequence</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th></th>
+                    <th>Fall</th>
+                    <th>Winter</th>
+                    <th>Summer</th>
+                </tr>
+            </thead>
+            <tbody>
+{tableRows}
+            </tbody>
+        </table>
+        <p>Approved by: ____________________________________________</p>
+        <p>Signature:____________________________&nbsp;&nbsp;Date: ______________</p>
+    </body>
+</html>

--- a/src/main/resources/sequenceTableTemplate.html
+++ b/src/main/resources/sequenceTableTemplate.html
@@ -18,7 +18,7 @@
                 border: 1px solid black;
                 text-align: center;
             }
-            h2 {
+            h2, h3 {
                 text-align: center;
             }
             p {
@@ -31,6 +31,7 @@
     </head>
     <body>
         <h2>My Proposed Sequence</h2>
+        {programName}
         <table>
             <thead>
                 <tr>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -71,5 +71,5 @@
         <servlet-name>FilterCourseCodes</servlet-name>
         <url-pattern>/api/filtercoursecodes</url-pattern>
     </servlet-mapping>
-
+    
 </web-app>

--- a/src/main/webapp/babel-src/appBarMenu.js
+++ b/src/main/webapp/babel-src/appBarMenu.js
@@ -22,11 +22,10 @@ export class AppBarMenu extends React.Component {
     }
     
     render() {
-
-        let exportSubMenu = EXPORT_TYPES.map(exportType =>
-            <MenuItem value={exportType}
-                      primaryText={"to " + exportType}
-                      onClick={() => this.props.onSelectExport(exportType)}/>);
+        let exportSubMenu = Object.keys(EXPORT_TYPES).map(exportType =>
+            <MenuItem value={EXPORT_TYPES[exportType]}
+                      primaryText={"to " + EXPORT_TYPES[exportType]}
+                      onClick={() => this.props.onSelectExport(EXPORT_TYPES[exportType])}/>);
 
         return (
             <IconMenu iconButtonElement={<IconButton  iconStyle={{color: "white"}}><MoreVertIcon/></IconButton>}

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -515,21 +515,34 @@ class MainPage extends React.Component {
      *      param exportType - string which indicates what file type to export to
      */
     exportSequence(exportType){
+        let requestExportType = "";
+        if(exportType === EXPORT_TYPES.EXPORT_TYPE_LIST_PDF || exportType === EXPORT_TYPES.EXPORT_TYPE_LIST_MD){
+            requestExportType = "list";
+        } else if(exportType === EXPORT_TYPES.EXPORT_TYPE_TABLE_PDF || exportType === EXPORT_TYPES.EXPORT_TYPE_TABLE_HTML){
+            requestExportType = "table";
+        }
         this.setState({
             "loadingExport": true
         }, () =>{
             $.ajax({
                 type: "POST",
                 url: "api/export",
-                data: JSON.stringify({"courseSequenceObject" : this.state.courseSequenceObject}),
+                data: JSON.stringify({"courseSequenceObject" : this.state.courseSequenceObject, "exportType": requestExportType}),
                 success: (response) => {
 
                     let downloadUrl = JSON.parse(response).exportPath;
-                    if(exportType === "MD" || exportType === "TXT"){
-                        downloadUrl = downloadUrl.replace("pdf", "md");
+
+                    let extension = "pdf";
+                    if(exportType === EXPORT_TYPES.EXPORT_TYPE_LIST_MD){
+                        extension = "md";
+                    }
+                    if(exportType === EXPORT_TYPES.EXPORT_TYPE_TABLE_HTML){
+                        extension = "html";
                     }
 
-                    saveAs(downloadUrl, "MySequence." + exportType.toLowerCase());
+                    downloadUrl = downloadUrl.replace("pdf", extension);
+
+                    saveAs(downloadUrl, "MySequence." + extension);
 
                     this.setState({"loadingExport" : false});
                 }

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -515,19 +515,29 @@ class MainPage extends React.Component {
      *      param exportType - string which indicates what file type to export to
      */
     exportSequence(exportType){
+        
         let requestExportType = "";
         if(exportType === EXPORT_TYPES.EXPORT_TYPE_LIST_PDF || exportType === EXPORT_TYPES.EXPORT_TYPE_LIST_MD){
             requestExportType = "list";
         } else if(exportType === EXPORT_TYPES.EXPORT_TYPE_TABLE_PDF || exportType === EXPORT_TYPES.EXPORT_TYPE_TABLE_HTML){
             requestExportType = "table";
         }
+
+        let sequenceInfo = this.state.courseSequenceObject.sequenceInfo;
+        let minTotalCredits = this.state.courseSequenceObject.minTotalCredits;
+        let programName = generatePrettyProgramName(sequenceInfo.program, sequenceInfo.option, sequenceInfo.entryType, minTotalCredits);
+        
         this.setState({
             "loadingExport": true
         }, () =>{
             $.ajax({
                 type: "POST",
                 url: "api/export",
-                data: JSON.stringify({"courseSequenceObject" : this.state.courseSequenceObject, "exportType": requestExportType}),
+                data: JSON.stringify({
+                    courseSequenceObject : this.state.courseSequenceObject, 
+                    exportType: requestExportType,
+                    programName: programName
+                }),
                 success: (response) => {
 
                     let downloadUrl = JSON.parse(response).exportPath;

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -105,7 +105,6 @@ export const PROGRAM_ENTRY_TYPES = {
     Coop: "Coop September"
 };
 
-// values are correspond to value of exportType property of export server request
 export const EXPORT_TYPES = {
     EXPORT_TYPE_TABLE_PDF: "PDF (table)",
     EXPORT_TYPE_TABLE_HTML: "HTML (table)",

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -70,6 +70,7 @@ export const UI_STRINGS = {
     LIST_NONE_SELECTED: "None Selected",
 
 };
+
 export const PROGRAM_NAMES = {
     SOEN: "Software Engineering",
     COMP: "Computer Science",

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -10,7 +10,6 @@ import React from "react";
 export const SEASON_NAMES_PRETTY = ["Fall", "Winter", "Summer"];
 export const SEASON_NAMES = SEASON_NAMES_PRETTY.map((season) => season.toLowerCase());
 export const DEFAULT_PROGRAM = "SOEN-General-Coop";
-export const EXPORT_TYPES = ["PDF", "MD", "TXT"];
 export const MAX_UNDO_HISTORY_LENGTH = 100;
 export const AUTO_SCROLL_PAGE_PORTION = 0.1; // auto scroll on the top and bottom 10% of screen
 export const AUTO_SCROLL_STEP = 10;
@@ -106,6 +105,14 @@ export const PROGRAM_ENTRY_TYPES = {
     Coop: "Coop September"
 };
 
+// values are correspond to value of exportType property of export server request
+export const EXPORT_TYPES = {
+    EXPORT_TYPE_TABLE_PDF: "PDF (table)",
+    EXPORT_TYPE_TABLE_HTML: "HTML (table)",
+    EXPORT_TYPE_LIST_PDF: "PDF (list)",
+    EXPORT_TYPE_LIST_MD: "TEXT (list)"
+};
+
 export function generatePrettyProgramName(program, option, entryType, minTotalCredits){
     return (
         PROGRAM_NAMES[program] + ", " +
@@ -113,7 +120,7 @@ export function generatePrettyProgramName(program, option, entryType, minTotalCr
         PROGRAM_ENTRY_TYPES[entryType] + " Entry" +
         (minTotalCredits ?  " (" + minTotalCredits + " credits)" : "")
     );
-}
+};
 
 /*
  *  Special object used by react-dnd to register a drag source

--- a/src/main/webapp/exports/manway.txt
+++ b/src/main/webapp/exports/manway.txt
@@ -8,4 +8,4 @@ manmanwei
 .
 .
 .
-For real though we need at least 1 file inside the exports folder otherwise the directory doesn't get created on the VM
+For real though we need at least 1 file inside the exports folder otherwise it doesn't get created on the VM


### PR DESCRIPTION
resolves #128 

## Summary

As per #128, I used `wkhtmltopdf` to generate pdf files from html. I used the following [gist](https://gist.github.com/paulsturgess/cfe1a59c7c03f1504c879d45787699f5) to help me install the program onto our VM.

I added a new function to the export servlet which converts the sequence json into an html page with a table representing the sequence. It performs this conversion in a very similar way to how the markdown list is generated. 

I changed the server API a little to accommodate this change:

- Added an `exportType` parameter, which can use the values `table` or `list` so as to select which type of export is to be performed. 
- Added a `programName` paramater, whose value is essentially just added in bold to the top of the page regardless of whether you're exporting to a list or table. The wiki will be changed accordingly once this PR is merged.

~I will need to update our REST API wiki page accordingly once this is PR merged.~ wiki has been updated