### PR TITLE
added feedback emailer servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,7 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
-
-
+        
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
@@ -85,11 +84,18 @@
             <version>3.4.2</version>
         </dependency>
 
-	<dependency>
+	    <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.5</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-email</artifactId>
+            <version>1.5</version>
+        </dependency>
+
 
     </dependencies>
 </project>

--- a/src/main/java/FeedbackSender.java
+++ b/src/main/java/FeedbackSender.java
@@ -27,7 +27,7 @@ public class FeedbackSender extends CPServlet {
         boolean success = true;
         try {
             Email email = new SimpleEmail();
-            email.setHostName("smtp.googlemail.com");
+            email.setHostName("smtp.gmail.com");
             email.setSmtpPort(465);
             email.setAuthenticator(new DefaultAuthenticator("concordiacourseplanner@gmail.com", "tranzone"));
             email.setSSLOnConnect(true);

--- a/src/main/java/FeedbackSender.java
+++ b/src/main/java/FeedbackSender.java
@@ -1,0 +1,54 @@
+import org.apache.commons.mail.DefaultAuthenticator;
+import org.apache.commons.mail.Email;
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.SimpleEmail;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class FeedbackSender extends CPServlet {
+
+    public void doPost(HttpServletRequest request,
+                       HttpServletResponse response)
+            throws ServletException, IOException
+    {
+
+        logger.info("---------User requested to send some feedback---------");
+
+        String feedbackMessage = (String) grabPropertyFromRequest("message", request);
+
+        logger.info("feedback message: " + feedbackMessage);
+        
+        boolean success = true;
+        try {
+            Email email = new SimpleEmail();
+            email.setHostName("smtp.googlemail.com");
+            email.setSmtpPort(465);
+            email.setAuthenticator(new DefaultAuthenticator("concordiacourseplanner@gmail.com", "tranzone"));
+            email.setSSLOnConnect(true);
+            email.setFrom("concordiacourseplanner@gmail.com");
+            email.setSubject("ConU Course Planner Feedback");
+            email.setMsg(feedbackMessage);
+            email.addTo("concordiacourseplanner@gmail.com");
+            email.send();
+        } catch(EmailException e){
+            success = false;
+        }
+
+        JSONObject responseObject = new JSONObject();
+        try {
+            responseObject.put("success", success);
+        } catch (JSONException e){
+            logger.info("Encountered a JSON error when setting response property: success");
+        }
+
+        logger.info("Responding with: " + responseObject.toString());
+        PrintWriter out = response.getWriter();
+        out.println(responseObject.toString());
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -72,4 +72,14 @@
         <url-pattern>/api/filtercoursecodes</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>FeedbackSender</servlet-name>
+        <servlet-class>FeedbackSender</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>FeedbackSender</servlet-name>
+        <url-pattern>/api/feedback</url-pattern>
+    </servlet-mapping>
+
 </web-app>


### PR DESCRIPTION
related to issue #133 

## Summary

Added a new servlet POST at `/api/feedback`. Basically you send it a `message` prop in the request:

```
{"message" : "your website sucks."}
```

and it responds with whether the email was sent succesfully: 

```
{"success" : "true"}
```

It uses the Apache commons email Java library to send the email. Just like the webscraping storers, it uses our gmail account concordiacourseplanner@gmail.com to authenticate with the gmail smtp server but it sends the email only to itself, not to all our personal gmails. So basically all the feedback we get will be listed as received emails if you log into that account on gmail.com.

## Test

Try sending the request on `courseplannerd`:

```
curl -H "Content-Type: application/json" -X POST -d '{"message": "your website sucks."}' http://conucourseplanner.online/courseplannerd/api/feedback
```

Then log in and make the sure the email was received.

*Hint: see diffs for gmail password* 😉 