### PR TITLE
Added hard coded, read-only course exemptions list

### DIFF
--- a/src/main/webapp/babel-src/sequenceValidationCard.js
+++ b/src/main/webapp/babel-src/sequenceValidationCard.js
@@ -3,7 +3,7 @@ import {Card, CardHeader, CardText} from 'material-ui/Card';
 import ErrorIcon from 'material-ui/svg-icons/alert/error';
 import WarningIcon from 'material-ui/svg-icons/alert/warning';
 
-import { UI_STRINGS, LOADING_ICON_TYPES } from "./util";
+import {UI_STRINGS, LOADING_ICON_TYPES, COURSE_EXEMPTIONS} from "./util";
 
 const ListItem = ({type, message, onMouseEnter, onMouseLeave}) => {
     return (
@@ -43,14 +43,21 @@ export class SequenceValidationCard extends React.Component {
 
             if(issue.type === "prerequisite" || issue.type === "corequisite"){
                 issue.data.unmetRequirements.forEach((requirement) => {
-                    listItems.push({
-                        type: itemType,
-                        positionsToHighlight: [issue.data.position],
-                        message : (
-                            issue.data.courseCode + " is missing " +
-                            issue.type + ": " + requirement.join(" or ")
-                        )
+                    let shouldSkip = false;
+                    // skip issues that include an exempted courseCode requirement
+                    requirement.forEach((courseCode) => {
+                        COURSE_EXEMPTIONS.indexOf(courseCode) >= 0 && (shouldSkip = true);
                     });
+                    if(!shouldSkip){
+                        listItems.push({
+                            type: itemType,
+                            positionsToHighlight: [issue.data.position],
+                            message : (
+                                issue.data.courseCode + " is missing " +
+                                issue.type + ": " + requirement.join(" or ")
+                            )
+                        });
+                    }
                 });
             }
 

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -113,6 +113,15 @@ export const EXPORT_TYPES = {
     EXPORT_TYPE_LIST_MD: "TEXT (list)"
 };
 
+export const COURSE_EXEMPTIONS = [
+    "MATH 203",
+    "MATH 204",
+    "MATH 205",
+    "CHEM 205",
+    "PHYS 204",
+    "PHYS 205"
+];
+
 export const INLINE_STYLES = {
     appBar: {
         zIndex: "0"


### PR DESCRIPTION
related to #141

## Summary

I found a [pdf document](http://www.concordia.ca/content/dam/encs/docs/Student%20Academic%20Services/ENCS%20Degree%20Transfer%20Information%20Sheet.pdf) which defines the list of courses that must be taken as prerequisites for both the engineering and computer science degrees. These two degrees encompass every single one of our currently offered recommended sequences. See actual list in diffs (util.js).

As per title, the user cannot edit this list of course exemptions. We can discuss at a later date whether we want to add that feature in.

Code changes are super simple. Will probably merge this within 24 hours.

## Test

Built & deployed to [d](http://conucourseplanner.online/courseplannerd). See that you won't see any issues which involve an unmet prereq coreq for any of the exempted courses.