### PR TITLE
Add aero support

### DIFF
--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -79,7 +79,8 @@ export const PROGRAM_NAMES = {
     INDU: "Industrial Engineering",
     MECH: "Mechanical Engineering",
     COEN: "Computer Engineering",
-    ELEC: "Electrical Engineering"
+    ELEC: "Electrical Engineering",
+    AERO: "Aerospace Engineering"
 };
 
 export const PROGRAM_OPTIONS = {
@@ -97,7 +98,10 @@ export const PROGRAM_OPTIONS = {
     Tele: "Telecommunications",
     Electronics: "Electronics/VLSI",
     Avionics: "Avionics and Control Systems",
-    Power: "Power and Renewable Energy"
+    Power: "Power and Renewable Energy",
+    A: "Aerodynamics and Propulsion",
+    B: "Aerospace Structures and Materials",
+    C: "Avionics and Aerospace Systems"
 };
 
 export const PROGRAM_ENTRY_TYPES = {

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -99,9 +99,9 @@ export const PROGRAM_OPTIONS = {
     Electronics: "Electronics/VLSI",
     Avionics: "Avionics and Control Systems",
     Power: "Power and Renewable Energy",
-    A: "Aerodynamics and Propulsion",
-    B: "Aerospace Structures and Materials",
-    C: "Avionics and Aerospace Systems"
+    Propulsion: "Aerodynamics and Propulsion",
+    Structures: "Aerospace Structures and Materials",
+    AeroSys: "Avionics and Aerospace Systems"
 };
 
 export const PROGRAM_ENTRY_TYPES = {

--- a/webscraping/courseSequences/scraping/scraper.js
+++ b/webscraping/courseSequences/scraping/scraper.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const SEASON_NAMES = ["fall", "winter", "summer"];
 const outputDir = "../scrapedJson/";
 
-const courseCodeRegex = /\w{4}\s?\d{3}/;
+const courseCodeRegex = /\w{4}\s{0,2}\d{3}/;
 const minTotalCreditsRegex = /\S*\d+\S*/;
 const seasonRegex = /fall|winter|summer/i;
 const workTermRegex = /work term/i;
@@ -351,7 +351,7 @@ function extractCourseObject(text){
     }
     else if(courseMatch){
         return {
-            "code": addMiddleSpaceIfNeeded(courseMatch[0].toUpperCase()),
+            "code": fixCourseCodeSpacing(courseMatch[0].toUpperCase()),
             "isElective": "false",
             "electiveType": ""
         };
@@ -497,15 +497,18 @@ function correctWrongCourses(semesterList, courseCorrectionMap){
     return semesterList;
 }
 
-function addMiddleSpaceIfNeeded(courseCode){
-    let pattern = new RegExp(/^\w{4}\d{3}$/);
-    let res = pattern.test(courseCode.trim());
-    if(res){
-        // add space where it needs to go
-        return courseCode.substr(0, 4) + " " + courseCode.substr(4);
-    } else {
+function fixCourseCodeSpacing(courseCode){
+    if(courseCode.length === 8){
         return courseCode;
     }
+    courseCode = courseCode.replace(String.fromCharCode(160)," ");
+    let numSpaces = 0;
+    for(let i = 0; i < courseCode.length; i++){
+        if(courseCode.charAt(i) === " "){
+            numSpaces++;
+        }
+    }
+    return courseCode.substr(0, 4) + " " + courseCode.substr(4 + numSpaces);
 }
 
 function parseSequenceInfo(sequenceID){

--- a/webscraping/courseSequences/scraping/scraper.js
+++ b/webscraping/courseSequences/scraping/scraper.js
@@ -115,7 +115,7 @@ function scrapeEncsSequenceUrl(url, outPath, plainFileName, onComplete){
 
             let semesterList = sequenceTextToSemesterList($(commonSequenceSelector).text());
 
-            semesterList = fixMechAndIndu(semesterList, plainFileName);
+            semesterList = performHardcodedPatches(semesterList, plainFileName);
             semesterList = correctWrongCourses(semesterList, courseCorrectionMap);
 
             let yearList = toYearList(semesterList);
@@ -407,9 +407,7 @@ function fillMissingSemesters(semesterList){
     return semesterList;
 }
 
-// perform fix for badly formatted INDU sequences
-function fixMechAndIndu(semesterList, programID){
-
+function performHardcodedPatches(semesterList, programID){
     let emptyWinter = {
         "season": "winter",
         "courseList": [],
@@ -427,6 +425,11 @@ function fixMechAndIndu(semesterList, programID){
     };
     let mech490 = {
         "code": "MECH 490",
+        "isElective": "false",
+        "electiveType": ""
+    };
+    let aero490 = {
+        "code": "AERO 490",
         "isElective": "false",
         "electiveType": ""
     };
@@ -465,6 +468,21 @@ function fixMechAndIndu(semesterList, programID){
         // add MECH 490 in fall and winter
         semesterList[semesterList.length-1].courseList.push(mech490);
         semesterList[semesterList.length-2].courseList.push(mech490);
+    }
+    if(programID.includes("AERO")){
+        let lastWinter = semesterList[semesterList.length-1];
+        if(programID.charAt(5) !== "C"){
+            semesterList.pop();
+            semesterList.pop();
+            semesterList.push(lastWinter);
+            if(!programID.includes("Coop")){
+                lastWinter.courseList.pop();
+            }
+            lastWinter.courseList.push(aero490);
+            semesterList[semesterList.length-2].courseList.push(aero490);
+        } else if(!programID.includes("Coop")){
+            lastWinter.courseList.pop();
+        }
     }
 
     return semesterList;

--- a/webscraping/courseSequences/scraping/scraper.js
+++ b/webscraping/courseSequences/scraping/scraper.js
@@ -483,6 +483,9 @@ function performHardcodedPatches(semesterList, programID){
         } else if(!programID.includes("Coop")){
             lastWinter.courseList.pop();
         }
+        if(programID.includes("Coop")){
+            lastWinter.isWorkTerm = "false";
+        }
     }
 
     return semesterList;

--- a/webscraping/courseSequences/scraping/scraper.js
+++ b/webscraping/courseSequences/scraping/scraper.js
@@ -471,7 +471,7 @@ function performHardcodedPatches(semesterList, programID){
     }
     if(programID.includes("AERO")){
         let lastWinter = semesterList[semesterList.length-1];
-        if(programID.charAt(5) !== "C"){
+        if(!programID.includes("AeroSys")){
             semesterList.pop();
             semesterList.pop();
             semesterList.push(lastWinter);

--- a/webscraping/courseSequences/scraping/sequenceUrls.json
+++ b/webscraping/courseSequences/scraping/sequenceUrls.json
@@ -88,5 +88,24 @@
     "Sept": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/sept-mech.html",
     "Jan": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/jan-mech.html",
     "Coop": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/co-op-mech.html"
+  },
+  "AERO": {
+    "Options": {
+      "A": {
+        "Sept": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/sept-aero-a.html",
+        "Jan": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/jan-aero-a.html",
+        "Coop": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/co-op-aero-a.html"
+      },
+      "B": {
+        "Sept": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/sept-aero-b.html",
+        "Jan": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/jan-aero-b.html",
+        "Coop": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/co-op-aero-b.html"
+      },
+      "C": {
+        "Sept": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/sept-aero-c.html",
+        "Jan": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/jan-aero-c.html",
+        "Coop": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/co-op-aero-c.html"
+      }
+    }
   }
 }

--- a/webscraping/courseSequences/scraping/sequenceUrls.json
+++ b/webscraping/courseSequences/scraping/sequenceUrls.json
@@ -91,17 +91,17 @@
   },
   "AERO": {
     "Options": {
-      "A": {
+      "Propulsion": {
         "Sept": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/sept-aero-a.html",
         "Jan": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/jan-aero-a.html",
         "Coop": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/co-op-aero-a.html"
       },
-      "B": {
+      "Structures": {
         "Sept": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/sept-aero-b.html",
         "Jan": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/jan-aero-b.html",
         "Coop": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/co-op-aero-b.html"
       },
-      "C": {
+      "AeroSys": {
         "Sept": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/sept-aero-c.html",
         "Jan": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/jan-aero-c.html",
         "Coop": "https://www.concordia.ca/encs/mechanical-industrial/students/undergraduate/course-sequences/co-op-aero-c.html"


### PR DESCRIPTION
resolves #143 

## Summary

- I added the urls for all the AERO course sequences (9 in total) to the webscraper, then resolved a few issues that were specific to the way AERO sequences are formatted.

- Made some slight frontend changes needed to pretty print the new program names.


## Test

The changes to the scraper have been reflected in the dev DB and the frontend changes are deployed to [d](http://conucourseplanner.online/courseplannerd). If you have the time, please check that all the 9 new programs properly reflect their source webpage.  This can easily be done by clicking the hyperlink on the program pretty name after selecting a program and then compare what shows up on our website vs Concordia's website.

P.S. We no longer have 69 course sequences 😢 