### PR TITLE
Add multi course drag 139

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "browserify": "^14.4.0",
     "bundle-collapser": "^1.2.1",
     "envify": "^4.1.0",
+    "immutability-helper": "^2.6.2",
     "material-ui": "^0.19.4",
     "react": "^15.6.1",
     "react-dnd": "^2.4.0",

--- a/src/main/webapp/babel-src/appBarMenu.js
+++ b/src/main/webapp/babel-src/appBarMenu.js
@@ -16,7 +16,6 @@ import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
  *  onSelectProgramChange - see MainPage.resetProgram
  *
  */
-//TODO: add feedback box ui component here (this is top menu bar)
 export class AppBarMenu extends React.Component {
 
     constructor(props){

--- a/src/main/webapp/babel-src/course.js
+++ b/src/main/webapp/babel-src/course.js
@@ -37,8 +37,8 @@ class Course extends React.Component {
     render() {
 
         let extraClassNames = [];
-        if(this.props.isBeingDragged) {
-            extraClassNames.push("beingDragged");
+        if(this.props.isHidden){
+            extraClassNames.push("isHidden");
         }
         if(this.props.isDraggable){
             extraClassNames.push("grabbable");

--- a/src/main/webapp/babel-src/course.js
+++ b/src/main/webapp/babel-src/course.js
@@ -29,7 +29,8 @@ class Course extends React.Component {
     }
 
     handleCourseClick(){
-        this.props.onCourseClick(this.props.courseObj.code);
+        let isElective = this.props.courseObj.isElective === "true";
+        this.props.onCourseClick(isElective ? "" : this.props.courseObj.code, this.props.position);
     }
 
     render() {
@@ -43,6 +44,9 @@ class Course extends React.Component {
         }
         if(this.props.isHighlighted){
             extraClassNames.push("highlighted");
+        }
+        if(this.props.isSelected){
+            extraClassNames.push("selected");
         }
 
         return this.props.connectDragSource(renderCourseDiv(this.props.courseObj, extraClassNames.join(" "), this.handleCourseClick));

--- a/src/main/webapp/babel-src/course.js
+++ b/src/main/webapp/babel-src/course.js
@@ -28,7 +28,8 @@ class Course extends React.Component {
         this.handleCourseClick = this.handleCourseClick.bind(this);
     }
 
-    handleCourseClick(){
+    handleCourseClick(event){
+        event.stopPropagation();
         let isElective = this.props.courseObj.isElective === "true";
         this.props.onCourseClick(isElective ? "" : this.props.courseObj.code, this.props.position);
     }

--- a/src/main/webapp/babel-src/courseInfoCard.js
+++ b/src/main/webapp/babel-src/courseInfoCard.js
@@ -14,12 +14,26 @@ import Course from "./course";
  *  Expects props:
  *
  *  courseInfo - see MainPage.state.selectedCourseInfo
+ *  onChangeDragState - see MainPage.state.setDragState
  *
  */
 export class CourseInfoCard extends React.Component {
 
     constructor(props){
         super(props);
+
+        this.state = {
+            courseBeingDragged: false
+        };
+
+        this.handleChangeDragState = this.handleChangeDragState.bind(this);
+    }
+
+    handleChangeDragState(isDragging, draggedPosition, draggedItem) {
+        this.props.onChangeDragState(isDragging, draggedPosition, draggedItem);
+        this.setState({
+            courseBeingDragged: isDragging
+        });
     }
 
     renderCardHeader(courseInfo) {
@@ -34,7 +48,11 @@ export class CourseInfoCard extends React.Component {
             showExpandableButton = false;
         } else {
             title = courseInfo.name + " - " + courseInfo.credits + " credits";
-            subtitle = <Course courseObj={courseInfo} isDraggable={true} onCourseClick={() => undefined}/>;
+            subtitle = <Course courseObj={courseInfo}
+                               isHidden={this.state.courseBeingDragged}
+                               isDraggable={true}
+                               onChangeDragState={this.handleChangeDragState}
+                               onCourseClick={() => undefined}/>;
             showExpandableButton = true;
         }
         

--- a/src/main/webapp/babel-src/dragPreview.js
+++ b/src/main/webapp/babel-src/dragPreview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DragLayer } from 'react-dnd';
-import { ITEM_TYPES, renderCourseDiv,renderOrListDiv } from "./util";
+import { renderCourseDiv, renderOrListDiv } from "./util";
 
 function collect(monitor){
     return {
@@ -40,22 +40,33 @@ function getItemStyles(props) {
 
 class DragPreview extends React.Component {
 
-    renderItem(type, item) {
-        switch (type) {
-            case ITEM_TYPES.COURSE:
-                return (
-                    renderCourseDiv(item.courseObj, " dragPreview")
-                );
-            case ITEM_TYPES.OR_LIST:
-                return (
-                    renderOrListDiv(item.courseList, " dragPreview")
-                );
-            default:
-                return "Default Drag Preview";
+    renderCourseList(courseList){
+
+        if(courseList.length === 0) {
+            return;
         }
+
+        return courseList.map((courseObj) => {
+            if(courseObj.length > 0){
+                let courseList = courseObj;
+                return (
+                    <div key={courseList.map(courseObj => courseObj.id).join()}>
+                        {renderOrListDiv(courseList, " dragPreview")}
+                    </div>
+                );
+            } else {
+                return (
+                    // course dragged from courseInfoCard will not have an id
+                    <div key={courseObj.id || courseObj.code}>
+                        {renderCourseDiv(courseObj, " dragPreview")}
+                    </div>
+                );
+            }
+        });
     }
 
     render() {
+
         if (!this.props.isDragging) {
             return null;
         }
@@ -63,7 +74,7 @@ class DragPreview extends React.Component {
         return (
             <div style={layerStyles}>
                 <div style={getItemStyles(this.props)}>
-                    {this.renderItem(this.props.itemType, this.props.item)}
+                    {this.renderCourseList(this.props.draggedItems)}
                 </div>
             </div>
         );

--- a/src/main/webapp/babel-src/garbageCan.js
+++ b/src/main/webapp/babel-src/garbageCan.js
@@ -44,4 +44,4 @@ function collectTarget(connect, monitor) {
     };
 }
 
-export default DropTarget(ITEM_TYPES.COURSE, garbageCanTarget, collectTarget)(GarbageCan);
+export default DropTarget([ITEM_TYPES.COURSE, ITEM_TYPES.OR_LIST], garbageCanTarget, collectTarget)(GarbageCan);

--- a/src/main/webapp/babel-src/garbageCan.js
+++ b/src/main/webapp/babel-src/garbageCan.js
@@ -7,7 +7,7 @@ import { DropTarget } from 'react-dnd';
  *
  *  Expects props:
  *
- *  onRemoveCourse - see MainPage.removeCourse
+ *  onRemoveCourses - see MainPage.removeCourses
  *
  */
 class GarbageCan extends React.Component {
@@ -33,7 +33,7 @@ let garbageCanTarget = {
     hover(props, monitor, component) {
     },
     drop(props, monitor, component){
-        props.onRemoveCourse(monitor.getItem().position);
+        props.onRemoveCourses();
     }
 };
 

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -6,19 +6,31 @@ import { DragDropContext } from 'react-dnd';
 import AppBar from 'material-ui/AppBar';
 import Dialog from 'material-ui/Dialog';
 
+let _ = require("underscore");
+
+import update from 'immutability-helper';
+
+update.extend('$auto', function(value, object) {
+    return object ?
+        update(object, value):
+        update({}, value);
+});
+update.extend('$autoArray', function(value, object) {
+    return object ?
+        update(object, value):
+        update([], value);
+});
+
 import {CourseInfoCard} from "./courseInfoCard";
 import {SequenceValidationCard} from "./sequenceValidationCard";
 import {SemesterTable} from "./semesterTable";
 import {SemesterList} from "./semesterList";
 import DragPreview from "./dragPreview";
-import {UI_STRINGS, generatePrettyProgramName} from "./util";
 import GarbageCan from "./garbageCan";
 import {AppBarMenu} from "./appBarMenu";
 import {SearchBox} from "./searchBox";
 import {ProgramSelectionDialog} from "./programSelectionDialog";
 import {FeedBackBox} from "./feedBackBox";
-
-let _ = require("underscore");
 
 import { MAX_UNDO_HISTORY_LENGTH,
          AUTO_SCROLL_PAGE_PORTION,
@@ -27,18 +39,23 @@ import { MAX_UNDO_HISTORY_LENGTH,
          EXPORT_TYPES,
          INLINE_STYLES,
          LOADING_ICON_TYPES,
+         UI_STRINGS,
+         generatePrettyProgramName,
          generateUniqueKey,
          generateUniqueKeys,
+         positionToString,
          saveAs } from "./util";
 
 
 /*
- *  Root component of our main page
- *
- *  This component loads up the saved/default sequence once it's created
+ *  Root component of main page
  *
  */
 class MainPage extends React.Component {
+
+    /*
+    *  Typical React lifecycle functions:
+    */
 
     constructor(props){
         super(props);
@@ -52,8 +69,7 @@ class MainPage extends React.Component {
                 warnings: [],
                 isLoading: false
             },
-            selectedCoursePositions: [],
-            highlightedCoursePositions: [],
+            positionStyleMap: {},
             chosenProgram: localStorage.getItem("chosenProgram"),
             allSequences: [],
             selectedCourseInfo: {},
@@ -64,6 +80,15 @@ class MainPage extends React.Component {
             showingFeedbackBox: false
         };
 
+        this.courseSequenceHistory = {
+            history: [],
+            currentPosition: -1
+        };
+        this.preventHistoryUpdate = false;
+        this.isDragging = false;
+        this.shouldScroll = false;
+        this.scrollDirection = 0;
+
         // functions that are passed as callbacks need to be bound to current class - see https://facebook.github.io/react/docs/handling-events.html
         this.updateChosenProgram = this.updateChosenProgram.bind(this);
         this.resetProgram = this.resetProgram.bind(this);
@@ -72,7 +97,7 @@ class MainPage extends React.Component {
         this.highlightCourses = this.highlightCourses.bind(this);
         this.unhighlightCourses = this.unhighlightCourses.bind(this);
         this.toggleCourseSelection = this.toggleCourseSelection.bind(this);
-        this.unselectCourses = this.unselectCourses.bind(this);
+        this.unselectAllCourses = this.unselectAllCourses.bind(this);
         this.toggleWorkTerm = this.toggleWorkTerm.bind(this);
         this.exportSequence = this.exportSequence.bind(this);
         this.validateSequence = this.validateSequence.bind(this);
@@ -80,7 +105,7 @@ class MainPage extends React.Component {
         this.moveCourse = this.moveCourse.bind(this);
         this.addCourse = this.addCourse.bind(this);
         this.removeCourse = this.removeCourse.bind(this);
-        this.changeDragState = this.changeDragState.bind(this);
+        this.setDragState = this.setDragState.bind(this);
         this.enableTextSelection = this.enableTextSelection.bind(this);
         this.performAutoScroll = this.performAutoScroll.bind(this);
         this.scrollPage = this.scrollPage.bind(this);
@@ -91,26 +116,30 @@ class MainPage extends React.Component {
         this.showFeedbackBox = this.showFeedbackBox.bind(this);
         this.closeFeedBackBox = this.closeFeedBackBox.bind(this);
         this.handleCourseClick = this.handleCourseClick.bind(this);
+        this.enableStyleOnPositions = this.enableStyleOnPositions.bind(this);
+        this.toggleStyleOnPositions = this.toggleStyleOnPositions.bind(this);
+        this.disableStyleOnAllPositions = this.disableStyleOnAllPositions.bind(this);
     }
 
+    /*
+     *  When the page first loads, get all the recommended sequences from the backend
+     *  and check local storage for a courseSequenceObject.
+     */
     componentDidMount() {
-        this.loadCourseSequenceObject();
         this.loadAllSequences();
-        this.courseSequenceHistory = {
-            "history": [],
-            "currentPosition": -1
-        };
-        this.preventHistoryUpdate = false;
-        this.isDragging = false;
-        this.shouldScroll = false;
-        this.scrollDirection = 0;
-        window.addEventListener('scroll', this.handleScroll);
+        this.loadCourseSequenceObject();
+        window.addEventListener("scroll", this.handleScroll);
     }
 
     componentWillUnmount() {
-        window.removeEventListener('scroll', this.handleScroll);
+        window.removeEventListener("scroll", this.handleScroll);
     }
 
+    /*
+     *  Each time the courseSequenceObject is updated, we want to trigger a sequence validation,
+     *  save the most recent version of courseSequenceObject to local storage,
+     *  and add a deep copy of courseSequenceObject to the courseSequenceHistory for undo/redo
+     */
     componentDidUpdate(prevProps, prevState){
         if(!_.isEqual(prevState.courseSequenceObject, this.state.courseSequenceObject) && !this.state.courseSequenceObject.isLoading){
 
@@ -134,361 +163,6 @@ class MainPage extends React.Component {
         }
     }
 
-    /*
-     *  function to call when the users starts or stops dragging any item
-     *      param isDragging - true if the user is dragging something
-     */
-    changeDragState(isDragging){
-        this.enableTextSelection(!isDragging);
-        this.enableGarbage(isDragging);
-        this.isDragging = isDragging;
-    }
-
-    /*
-     *  function to call to disable text selection on the page
-     *  it is used to fix an issue in firefox where text on the page gets highlighted while dragging a course
-     *      param enabled - should the garbage can be enabled
-     */
-    enableTextSelection(enabled){
-        this.setState({
-            "allowingTextSelection": enabled
-        });
-    }
-
-    /*
-     *  function to call when we want to display the garbage can and allow the user to delete a course
-     *      param enabled - should the garbage can be enabled
-     */
-    enableGarbage(enabled){
-        this.setState({
-            "showingGarbage": enabled
-        });
-    }
-
-    /*
-     *  function to call in the event that the user selects a new program of study
-     *      param newChosenProgram - the name of the chosen program (e.g. SOEN-General-Coop);
-     *                               directly links to _id value of sequence in courseSequences DB
-     */
-    updateChosenProgram(newChosenProgram){
-
-        // remember the program selected by the user
-        newChosenProgram ? localStorage.setItem("chosenProgram", newChosenProgram) :
-                           localStorage.removeItem("chosenProgram");
-        // clear the saved sequence to force a reloading of the user's chosen program
-        localStorage.removeItem("savedSequence");
-
-        // Must use the callback param of setState to ensure the chosenProgram is changed in time
-        this.setState({"chosenProgram": newChosenProgram}, this.loadCourseSequenceObject);
-    }
-
-    /*
-     *  function to call in the event that the user wishes to select a different program of study
-     *  TODO: (INSERT CONFIRM BOX HERE - MAKE SURE USER DOESN'T LOSE THEIR WORK BY ACCIDENTALLY CHANGING PROGRAMS)
-     */
-    resetProgram(){
-        this.updateChosenProgram(undefined);
-    }
-
-    showFeedbackBox() {
-        this.setState({
-            showingFeedbackBox: true
-        });
-    }
-
-    closeFeedBackBox() {
-        this.setState({
-           showingFeedbackBox: false
-        });
-    }
-
-    /*
-     *  function to call in the event that the user selects an item from a list of choice courses (AKA orList)
-     *      param coursePosition - object indicating the absolute position of the course within the sequence
-     *                             required properties: yearIndex, season, courseIndex, orListIndex
-     */
-    setOrListCourseSelected(coursePosition){
-        this.setState((prevState) => {
-
-            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
-
-            // update isSelected property of items in orList in question
-            let orList = courseSequenceObjectCopy.yearList[coursePosition.yearIndex][coursePosition.season].courseList[coursePosition.courseIndex];
-
-            orList = orList.map((courseObj, orListIndex) => {
-                courseObj.isSelected = (orListIndex === coursePosition.orListIndex);
-                return courseObj;
-            });
-
-            // set new state based on changes
-            return {
-                "courseSequenceObject": courseSequenceObjectCopy
-            };
-        });
-    }
-
-    /*
-     *  function to call in the event that the user hovers over a sequence validation results item
-     *      param positions - array of objects indicating the absolute position of the course within the sequence
-     */
-    highlightCourses(positions){
-        this.setState((prevState) => {
-            return {
-                highlightedCoursePositions: JSON.parse(JSON.stringify(prevState.highlightedCoursePositions)).concat(positions)
-            }
-        });
-    }
-
-    /*
-     *  function to call in the event that the user hovers out of a sequence validation results item
-     *      param positions - array of objects indicating the absolute position of the course within the sequence
-     */
-    unhighlightCourses(positions){
-        this.setState((prevState) => {
-            let newHighlightedPositions = [];
-            prevState.highlightedCoursePositions.forEach((highlightedPosition) => {
-                if(positions.indexOf(highlightedPosition) === -1){
-                    newHighlightedPositions.push(highlightedPosition);
-                }
-            });
-            return {
-                highlightedCoursePositions: newHighlightedPositions
-            }
-        });
-    }
-
-    /*
-     *  function to call in the event that the user clicks on a course
-     *      param position - object indicating the absolute position of the course within the sequence
-     */
-    toggleCourseSelection(position){
-        this.setState((prevState) => {
-            let newSelectedPositions = [];
-            prevState.selectedCoursePositions.forEach((selectedPosition) => {
-                if(!_.isEqual(position, selectedPosition)){
-                    newSelectedPositions.push(selectedPosition);
-                }
-            });
-            if(newSelectedPositions.length === prevState.selectedCoursePositions.length){
-                newSelectedPositions.push(position);
-            }
-            return {
-                selectedCoursePositions: newSelectedPositions
-            }
-        });
-    }
-
-    /*
-     *  function to call in the event that the user clicks on something other than a course
-     */
-    unselectCourses(){
-        this.setState({
-            selectedCoursePositions: []
-        });
-    }
-
-    /*
-     *  function to call in the event that the user toggles whether a semester is a work term or not
-     *      param yearIndex - index of the year of the semester
-     *      param season - the season of the semester
-     */
-    toggleWorkTerm(yearIndex, season){
-        this.setState((prevState) => {
-
-            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
-
-            // updated isWorkTerm property of semester in question
-            let isWorkTerm = courseSequenceObjectCopy.yearList[yearIndex][season].isWorkTerm;
-            courseSequenceObjectCopy.yearList[yearIndex][season].isWorkTerm = (isWorkTerm === "true") ? "false" : "true";
-
-            // set new state based on changes
-            return {
-                "courseSequenceObject": courseSequenceObjectCopy
-            };
-        });
-    }
-
-    /*
-     *  function to call when we want to display the garbage can and allow the user to delete a course
-     *      param enabled - should the garbage can be enabled
-     */
-    enableGarbage(enabled){
-        this.setState({
-            "showingGarbage": enabled
-        });
-    }
-
-    /*
-     *  function to call in the event that the user drags an existing course into a new position
-     *      param oldPosition - object indicating the absolute position of the course within the sequence
-     *                          required properties: yearIndex, season, courseIndex
-     *      param newPosition - ''
-     */
-    moveCourse(oldPosition, newPosition){
-        this.setState((prevState) => {
-
-            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
-
-            let courseToMove = courseSequenceObjectCopy.yearList[oldPosition.yearIndex][oldPosition.season].courseList[oldPosition.courseIndex];
-
-            // remove course from old position and insert at new position
-            courseSequenceObjectCopy.yearList[oldPosition.yearIndex][oldPosition.season].courseList.splice(oldPosition.courseIndex, 1);
-            courseSequenceObjectCopy.yearList[newPosition.yearIndex][newPosition.season].courseList.splice(newPosition.courseIndex, 0, courseToMove);
-
-            // set new state based on changes
-            return {
-                "courseSequenceObject": courseSequenceObjectCopy
-            };
-        });
-    }
-
-    /*
-     *  function to call in the event that the user drags a new course into a new position
-     *      param courseObj - object representing the course to be added
-     *      param newPosition - object indicating the new absolute position of the course within the sequence
-     *                          required properties: yearIndex, season, courseIndex
-     */
-    addCourse(courseObj, newPosition){
-        this.setState((prevState) => {
-
-            // generate a unique key for the course
-            courseObj.id = generateUniqueKey(courseObj, newPosition.season, newPosition.yearIndex, newPosition.courseIndex, "");
-            courseObj.isElective = "false";
-            courseObj.electiveType = "";
-
-            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
-
-            // insert course at new position
-            courseSequenceObjectCopy.yearList[newPosition.yearIndex][newPosition.season].courseList.splice(newPosition.courseIndex, 0, courseObj);
-
-            // set new state based on changes
-            return {
-                "courseSequenceObject": courseSequenceObjectCopy
-            };
-        });
-    }
-
-    /*
-     *  function to call in the event that the user wants to remove a course from the sequence
-     *      param coursePosition - object indicating the new absolute position of the course within the sequence
-     *                             required properties: yearIndex, season, courseIndex
-     */
-    removeCourse(coursePosition){
-        this.setState((prevState) => {
-
-            let courseSequenceObjectCopy = JSON.parse(JSON.stringify(prevState.courseSequenceObject));
-
-            // remove course at coursePosition
-            courseSequenceObjectCopy.yearList[coursePosition.yearIndex][coursePosition.season].courseList.splice(coursePosition.courseIndex, 1);
-
-            // set new state based on changes
-            return {
-                "courseSequenceObject": courseSequenceObjectCopy
-            };
-        });
-    }
-
-    handleTouchMove(touchMoveEvent){
-        this.performAutoScroll(touchMoveEvent.changedTouches[0].clientY, touchMoveEvent.view.innerHeight);
-    }
-
-    handleMouseMove(mouseMoveEvent){
-        this.performAutoScroll(mouseMoveEvent.clientY, mouseMoveEvent.view.innerHeight);
-    }
-
-    /*
-     *  function which decides whether or not the page should scroll based on the position of the user's cursor
-     *      param y - number indicating the y coordinate of the user's cursor, where the top of the page is y = 0
-     *      param pageHeight - number indicating the total height of the page in pixels
-     */
-    performAutoScroll(y, pageHeight){
-        if(this.isDragging) {
-            let scrollAreaHeight = pageHeight * AUTO_SCROLL_PAGE_PORTION;
-
-            if(y > scrollAreaHeight && y < pageHeight - scrollAreaHeight){
-                this.shouldScroll = false;
-                return;
-            }
-
-            // don't call scrollPage if it's already running
-            if(this.shouldScroll){
-                return;
-            }
-
-            if (y <= scrollAreaHeight) {
-                this.scrollDirection = -1;
-                this.shouldScroll = true;
-                this.scrollPage();
-            }
-            if (y >= pageHeight - scrollAreaHeight) {
-                this.scrollDirection = 1;
-                this.shouldScroll = true;
-                this.scrollPage();
-            }
-        } else {
-            this.shouldScroll = false;
-        }
-    }
-
-    /*
-     *  recursive function which continuously scrolls up or down the page until this.shouldScroll becomes false
-     */
-    scrollPage(){
-        setTimeout(() => {
-            window.scrollBy(0, this.scrollDirection * AUTO_SCROLL_STEP);
-            if(this.shouldScroll){
-                this.scrollPage();
-            }
-        }, AUTO_SCROLL_DELAY);
-    }
-
-    /*
-     *  event handler for key presses
-     */
-    handleKeyPress(keyDownEvent){
-        if(keyDownEvent.keyCode === 90 && keyDownEvent.ctrlKey){
-            let changedCurrentPosition = false;
-            if(keyDownEvent.shiftKey){
-                // do a redo op
-                if(this.courseSequenceHistory.currentPosition < this.courseSequenceHistory.history.length - 1){
-                    this.courseSequenceHistory.currentPosition++;
-                    changedCurrentPosition = true;
-                }
-            } else {
-                // do an undo op
-                if(this.courseSequenceHistory.currentPosition > 0){
-                    this.courseSequenceHistory.currentPosition--;
-                    changedCurrentPosition = true;
-                }
-            }
-            if(changedCurrentPosition){
-                // prevent the componentDidUpdate method from updating our undo history
-                this.preventHistoryUpdate = true;
-                // update state
-                this.setState({
-                    "courseSequenceObject": this.courseSequenceHistory.history[this.courseSequenceHistory.currentPosition]
-                });
-            }
-        }
-    }
-
-    /*
-     *  detatch the IOPanel if we scroll lower than 80px
-     */
-    handleScroll(){
-        this.setState({
-            detachIOPanel: window.scrollY > 80
-        });
-    }
-
-    /*
-     */
-    handleCourseClick(courseCode, coursePosition){
-        this.toggleCourseSelection(coursePosition);
-        if(courseCode){
-            this.loadCourseInfo(courseCode);
-        }
-    }
 
     renderAppBarTitle() {
         let siteName = <div className="siteNameLabel">{UI_STRINGS.SITE_NAME}</div>;
@@ -509,13 +183,15 @@ class MainPage extends React.Component {
                  className={"mainPage" + (this.state.allowingTextSelection ? "" : " textSelectionOff")}
                  onMouseMove={this.handleMouseMove}
                  onTouchMove={this.handleTouchMove}
-                 onKeyDown={this.handleKeyPress}>
+                 onKeyDown={this.handleKeyPress}
+                 onClick={this.unselectAllCourses}>
                 <AppBar title={this.renderAppBarTitle()}
                         showMenuIconButton={false}
                         className="appBar"
                         style={INLINE_STYLES.appBar}
                         iconElementRight={this.state.showingGarbage ? <GarbageCan onRemoveCourse={this.removeCourse}/> : <AppBarMenu onSelectExport={this.exportSequence}
-                                                                                                                                     onSelectProgramChange={this.resetProgram} onSelectFeedback={this.showFeedbackBox}/>}/>
+                                                                                                                                     onSelectProgramChange={this.resetProgram}
+                                                                                                                                     onSelectFeedback={this.showFeedbackBox}/>}/>
                 <div className="pageContent">
                     <div className={"ioPanelContainer" + (this.state.detachIOPanel ? " detached" : "")}>
                         <div className="ioPanel">
@@ -533,8 +209,7 @@ class MainPage extends React.Component {
                     <div className="semesterTableContainer hidden-xs hidden-sm">
                         <div className="programPrettyName"><a href={sourceUrl} target="_blank">{programPrettyName}</a></div>
                         <SemesterTable courseSequenceObject={this.state.courseSequenceObject}
-                                       highlightedCoursePositions={this.state.highlightedCoursePositions}
-                                       selectedCoursePositions={this.state.selectedCoursePositions}
+                                       positionStyleMap={this.state.positionStyleMap}
                                        onSelectCourse={this.handleCourseClick}
                                        onOrListSelection={this.setOrListCourseSelected}
                                        onToggleWorkTerm={this.toggleWorkTerm}
@@ -545,8 +220,7 @@ class MainPage extends React.Component {
                     <div className="semesterListContainer col-xs-8 col-xs-offset-2 hidden-md hidden-lg">
                         <div className="programPrettyName"><a href={sourceUrl} target="_blank">{programPrettyName}</a></div>
                         <SemesterList courseSequenceObject={this.state.courseSequenceObject}
-                                      highlightedCoursePositions={this.state.highlightedCoursePositions}
-                                      selectedCoursePositions={this.state.selectedCoursePositions}
+                                      positionStyleMap={this.state.positionStyleMap}
                                       onSelectCourse={this.handleCourseClick}
                                       onOrListSelection={this.setOrListCourseSelected}
                                       onToggleWorkTerm={this.toggleWorkTerm}
@@ -567,11 +241,474 @@ class MainPage extends React.Component {
                                             allSequences={this.state.allSequences}
                                             onChangeChosenProgram={this.updateChosenProgram}/>
                     <FeedBackBox open={this.state.showingFeedbackBox}
-                                 onRequestClose={this.closeFeedBackBox}>
-                    </FeedBackBox>
+                                 onRequestClose={this.closeFeedBackBox}/>
                 </div>
             </div>
         );
+    }
+
+    /*
+    *  Course sequence object mutators:
+    */
+
+    /*
+     *  Function to call in the event that the user drags an existing course into a new position
+     *      param oldPosition - object indicating the absolute position of the course within the sequence
+     *                          required properties: yearIndex, season, courseIndex
+     *      param newPosition - ''
+     */
+    moveCourse(oldPosition, newPosition){
+        this.setState((prevState) => {
+
+            let courseToMove = prevState.courseSequenceObject.yearList[oldPosition.yearIndex][oldPosition.season].courseList[oldPosition.courseIndex];
+
+            let removeCommand = {
+                yearList: {
+                    [oldPosition.yearIndex]: {
+                        [oldPosition.season]: {
+                            courseList: {$splice: [[oldPosition.courseIndex, 1]]}
+                        }
+                    }
+                }
+            };
+
+            let addCommand = {
+                yearList: {
+                    [newPosition.yearIndex]: {
+                        [newPosition.season]: {
+                            courseList: {$splice: [[newPosition.courseIndex, 0, courseToMove]]}
+                        }
+                    }
+                }
+            };
+
+            // set new state based on changes
+            return {
+                courseSequenceObject: update(update(prevState.courseSequenceObject, removeCommand), addCommand)
+            };
+        });
+    }
+
+    /*
+     *  Function to call in the event that the user drags a new course into a new position
+     *      param courseObj - object representing the course to be added
+     *      param newPosition - object indicating the new absolute position of the course within the sequence
+     *                          required properties: yearIndex, season, courseIndex
+     */
+    addCourse(courseObj, newPosition){
+        this.setState((prevState) => {
+
+            courseObj.id = generateUniqueKey(courseObj, newPosition.season, newPosition.yearIndex, newPosition.courseIndex, "");
+            courseObj.isElective = "false";
+            courseObj.electiveType = "";
+
+            let addCommand = {
+                yearList: {
+                    [newPosition.yearIndex]: {
+                        [newPosition.season]: {
+                            courseList: {$splice: [[newPosition.courseIndex, 0, courseObj]]}
+                        }
+                    }
+                }
+            };
+
+            return {
+                courseSequenceObject: update(prevState.courseSequenceObject, addCommand)
+            };
+        });
+    }
+
+    /*
+     *  Function to call in the event that the user wants to remove a course from the sequence
+     *      param coursePosition - object indicating the new absolute position of the course within the sequence
+     *                             required properties: yearIndex, season, courseIndex
+     */
+    removeCourse(coursePosition){
+        this.setState((prevState) => {
+
+            let removeCommand = {
+                yearList: {
+                    [coursePosition.yearIndex]: {
+                        [coursePosition.season]: {
+                            courseList: {$splice: [[coursePosition.courseIndex, 1]]}
+                        }
+                    }
+                }
+            };
+
+            return {
+                courseSequenceObject: update(prevState.courseSequenceObject, removeCommand)
+            };
+        });
+    }
+
+    /*
+     *  Performs an undo or redo operation
+     *      param isShiftKeyPressed - will do a redo op if shift is pressed, otherwise will do undo op
+     */
+    performUndoRedo(isShiftKeyPressed){
+        let changedCurrentPosition = false;
+        if(isShiftKeyPressed){
+            // do a redo op
+            if(this.courseSequenceHistory.currentPosition < this.courseSequenceHistory.history.length - 1){
+                this.courseSequenceHistory.currentPosition++;
+                changedCurrentPosition = true;
+            }
+        } else {
+            // do an undo op
+            if(this.courseSequenceHistory.currentPosition > 0){
+                this.courseSequenceHistory.currentPosition--;
+                changedCurrentPosition = true;
+            }
+        }
+        if(changedCurrentPosition){
+            // prevent the componentDidUpdate method from updating our undo history
+            this.preventHistoryUpdate = true;
+            // update state
+            this.setState({
+                courseSequenceObject: this.courseSequenceHistory.history[this.courseSequenceHistory.currentPosition]
+            });
+        }
+    }
+
+    /*
+     *  Function to call in the event that the user selects an item from a list of choice courses (AKA orList)
+     *      param coursePosition - object indicating the absolute position of the course within the sequence
+     *                             required properties: yearIndex, season, courseIndex, orListIndex
+     */
+    setOrListCourseSelected(coursePosition){
+        this.setState((prevState) => {
+
+            // update isSelected property of items in orList in question
+            let orList = prevState.courseSequenceObject.yearList[coursePosition.yearIndex][coursePosition.season].courseList[coursePosition.courseIndex];
+
+            let orListUpdateCommand = {};
+
+            orList.forEach((courseObj, orListIndex) => {
+                orListUpdateCommand[orListIndex] = {
+                    isSelected: {$set: (orListIndex === coursePosition.orListIndex)}
+                };
+            });
+
+            let newOrList = update(orList, orListUpdateCommand);
+
+            let fullUpdateCommand = {
+                yearList: {
+                    [coursePosition.yearIndex]: {
+                        [coursePosition.season]: {
+                            courseList: {
+                                [coursePosition.courseIndex]: {$set: newOrList}
+                            }
+                        }
+                    }
+                }
+            };
+
+            return {
+                courseSequenceObject: update(prevState.courseSequenceObject, fullUpdateCommand)
+            };
+        });
+    }
+
+    /*
+     *  Function to call in the event that the user toggles whether a semester is a work term or not
+     *      param yearIndex - index of the year of the semester
+     *      param season - the season of the semester
+     */
+    toggleWorkTerm(yearIndex, season){
+        this.setState((prevState) => {
+            let newValue = prevState.courseSequenceObject.yearList[yearIndex][season].isWorkTerm === "true" ? "false" : "true";
+            return {
+                courseSequenceObject: update(prevState.courseSequenceObject, {
+                    yearList: {
+                        [yearIndex]: {
+                            [season]: {
+                                isWorkTerm: {$set: newValue}
+                            }
+                        }
+                    }
+                })
+            };
+        });
+    }
+
+    /*
+    *  Position style map mutators:
+    */
+
+    /*
+     *  Function to call in the event that the user hovers over a sequence validation results item
+     *      param positions - array of objects indicating the absolute position of the course within the sequence
+     */
+    highlightCourses(positions){
+        this.enableStyleOnPositions(positions, "isHighlighted", true);
+    }
+
+    /*
+     *  Function to call in the event that the user hovers out of a sequence validation results item
+     *      param positions - array of objects indicating the absolute position of the course within the sequence
+     */
+    unhighlightCourses(positions){
+        this.enableStyleOnPositions(positions, "isHighlighted", false);
+    }
+
+    /*
+     *  Function to call in the event that the user clicks on a course
+     *      param position - object indicating the absolute position of the course within the sequence
+     */
+    toggleCourseSelection(position){
+        this.toggleStyleOnPositions([position], "isSelected");
+    }
+
+    /*
+     *  function to call in the event that the user clicks on something other than a course
+     */
+    unselectAllCourses(){
+        this.disableStyleOnAllPositions("isSelected");
+    }
+
+    /*
+     *  Enable/disable boolean property for a specific position in the positionStyleMap
+     *      param position - the position of the item that is to be styled
+     *      param styleName - the name of the property
+     *      param enabled - the boolean value to assign to the property
+     */
+    enableStyleOnPositions(positions, styleName, enabled){
+        this.setState((prevState) => {
+            let updateCommand = {};
+            positions.forEach((position) => {
+                updateCommand[positionToString(position)] = {$auto: {
+                        [styleName]: {$auto: {$set: enabled}}
+                    }
+                };
+            });
+            return {
+                positionStyleMap: update(prevState.positionStyleMap, updateCommand),
+            }
+        });
+    }
+
+    /*
+     *  Toggle boolean property for a specific position in the positionStyleMap
+     *      param position - the position of the item that is to be styled
+     *      param styleName - the name of the property
+     */
+    toggleStyleOnPositions(positions, styleName){
+        this.setState((prevState) => {
+            let updateCommand = {};
+            positions.forEach((position) => {
+                updateCommand[positionToString(position)] = {$auto: {
+                        $toggle: [styleName]
+                    }
+                };
+            });
+            return {
+                positionStyleMap: update(prevState.positionStyleMap, updateCommand),
+            }
+        });
+    }
+
+    /*
+     *  Set boolean property to false on all positions in positionStyleMap
+     *      param styleName - the name of the property
+     */
+    disableStyleOnAllPositions(styleName){
+        this.setState((prevState) => {
+            let updateCommand = {};
+            Object.keys(prevState.positionStyleMap).forEach((positionString) => {
+                updateCommand[positionString] = {$auto: {
+                        [styleName]: {$auto: {$set: false}}
+                    }
+                };
+            });
+            return {
+                positionStyleMap: update(prevState.positionStyleMap, updateCommand),
+            }
+        });
+    }
+
+    /*
+    *  Event handlers
+    */
+
+    /*
+     *  Event handler for cursor movement on touch devices
+     */
+    handleTouchMove(touchMoveEvent){
+        this.performAutoScroll(touchMoveEvent.changedTouches[0].clientY, touchMoveEvent.view.innerHeight);
+    }
+
+    /*
+     *  Event handler for cursor movement on mouse devices
+     */
+    handleMouseMove(mouseMoveEvent){
+        this.performAutoScroll(mouseMoveEvent.clientY, mouseMoveEvent.view.innerHeight);
+    }
+
+    /*
+     *  Event handler for key presses
+     */
+    handleKeyPress(keyDownEvent){
+        if(keyDownEvent.keyCode === 90 && keyDownEvent.ctrlKey){
+            this.performUndoRedo(keyDownEvent.shiftKey);
+        }
+    }
+
+    /*
+     *  Event handler for page scrolling
+     */
+    handleScroll(){
+        // detatch the IOPanel if we scroll lower than 80px
+        this.setState({
+            detachIOPanel: window.scrollY > 80
+        });
+    }
+
+    /*
+     * Function to call in the event that a course item is clicked on
+     *     param courseCode - the code of the clicked course; will load it's info if defined
+     *     param coursePosition - the position in the sequence of the course or orList
+     */
+    handleCourseClick(courseCode, coursePosition){
+        this.toggleCourseSelection(coursePosition);
+        if(courseCode){
+            this.loadCourseInfo(courseCode);
+        }
+    }
+
+    /*
+    *  Auxiliary functions
+    */
+
+    /*
+     *  Function to call when the users starts or stops dragging any item
+     *      param isDragging - true if the user is dragging something
+     */
+    setDragState(isDragging){
+        this.enableTextSelection(!isDragging);
+        this.enableGarbage(isDragging);
+        this.isDragging = isDragging;
+    }
+
+    /*
+     *  Function to call to disable text selection on the page
+     *  used to fix an issue in firefox where text on the page gets highlighted while dragging a course
+     *      param enabled - should the garbage can be enabled
+     */
+    enableTextSelection(enabled){
+        this.setState({
+            allowingTextSelection: enabled
+        });
+    }
+
+    /*
+     *  Function to call when we want to display the garbage can and allow the user to delete a course
+     *      param enabled - should the garbage can be enabled
+     */
+    enableGarbage(enabled){
+        this.setState({
+            showingGarbage: enabled
+        });
+    }
+
+    /*
+     *  Function to call in the event that the user selects a new program of study
+     *      param newChosenProgram - the name of the chosen program (e.g. SOEN-General-Coop);
+     *                               directly links to _id value of sequence in courseSequences DB
+     */
+    updateChosenProgram(newChosenProgram){
+
+        // remember the program selected by the user
+        newChosenProgram ? localStorage.setItem("chosenProgram", newChosenProgram) :
+            localStorage.removeItem("chosenProgram");
+        // clear the saved sequence to force a reloading of the user's chosen program
+        localStorage.removeItem("savedSequence");
+
+        // Must use the callback param of setState to ensure the chosenProgram is changed in time
+        this.setState({chosenProgram: newChosenProgram}, this.loadCourseSequenceObject);
+    }
+
+    /*
+     *  Function to call in the event that the user wishes to select a different program of study
+     *  TODO: (INSERT CONFIRM BOX HERE - MAKE SURE USER DOESN'T LOSE THEIR WORK BY ACCIDENTALLY CHANGING PROGRAMS)
+     */
+    resetProgram(){
+        this.updateChosenProgram(undefined);
+    }
+
+    /*
+     *  Function to call when we want to display the garbage can and allow the user to delete a course
+     *      param enabled - should the garbage can be enabled
+     */
+    enableGarbage(enabled){
+        this.setState({
+            showingGarbage: enabled
+        });
+    }
+
+    /*
+     *  Function which decides whether or not the page should scroll based on the position of the user's cursor
+     *  and initiates automatic page scrolling accordingly
+     *      param y - number indicating the y coordinate of the user's cursor, where the top of the page is y = 0
+     *      param pageHeight - number indicating the total height of the page in pixels
+     */
+    performAutoScroll(y, pageHeight){
+        if(this.isDragging){
+            let scrollAreaHeight = pageHeight * AUTO_SCROLL_PAGE_PORTION;
+
+            if(y > scrollAreaHeight && y < pageHeight - scrollAreaHeight){
+                this.shouldScroll = false;
+                return;
+            }
+
+            // don't call scrollPage if it's already running
+            if(this.shouldScroll){
+                return;
+            }
+
+            if(y <= scrollAreaHeight){
+                this.scrollDirection = -1;
+                this.shouldScroll = true;
+                this.scrollPage();
+            }
+            if(y >= pageHeight - scrollAreaHeight){
+                this.scrollDirection = 1;
+                this.shouldScroll = true;
+                this.scrollPage();
+            }
+        } else {
+            this.shouldScroll = false;
+        }
+    }
+
+    /*
+     *  Recursive function which continuously scrolls up or down the page until this.shouldScroll becomes false
+     */
+    scrollPage(){
+        setTimeout(() => {
+            window.scrollBy(0, this.scrollDirection * AUTO_SCROLL_STEP);
+            if(this.shouldScroll){
+                this.scrollPage();
+            }
+        }, AUTO_SCROLL_DELAY);
+    }
+
+    /*
+     *  Function to call when we want to display the feedback box dialog
+     */
+    showFeedbackBox() {
+        this.setState({
+            showingFeedbackBox: true
+        });
+    }
+
+    /*
+     *  Function to call when we want to hide the feedback box dialog
+     */
+    closeFeedBackBox() {
+        this.setState({
+            showingFeedbackBox: false
+        });
     }
 
     /*
@@ -586,8 +723,8 @@ class MainPage extends React.Component {
         }
 
         // set the courseSequenceObject to loading state then load its data
-        this.setState({"courseSequenceObject" : {
-            "isLoading": true
+        this.setState({courseSequenceObject : {
+            isLoading: true
         }}, () => {
             let courseSequenceObject = JSON.parse(localStorage.getItem("savedSequence"));
 
@@ -604,13 +741,13 @@ class MainPage extends React.Component {
                     success: (response) => {
                         let courseSequenceObject = JSON.parse(response).courseSequenceObject;
                         courseSequenceObject.yearList = generateUniqueKeys(courseSequenceObject.yearList);
-                        this.setState({"courseSequenceObject" : courseSequenceObject});
+                        this.setState({courseSequenceObject : courseSequenceObject});
                         localStorage.setItem("savedSequence", JSON.stringify(courseSequenceObject));
                     }
                 });
 
             } else {
-                this.setState({"courseSequenceObject" : courseSequenceObject});
+                this.setState({courseSequenceObject : courseSequenceObject});
             }
         });
     }
@@ -621,7 +758,7 @@ class MainPage extends React.Component {
             type: "GET",
             url: "api/allsequences",
             success: (response) => {
-                this.setState({"allSequences" : JSON.parse(response)});
+                this.setState({allSequences : JSON.parse(response)});
             }
         });
     }
@@ -631,15 +768,15 @@ class MainPage extends React.Component {
      *      param courseCode - the code of the chosen course
      */
     loadCourseInfo(courseCode){
-        this.setState({"selectedCourseInfo" : {
-            "isLoading" : true
+        this.setState({selectedCourseInfo : {
+            isLoading : true
         }}, () => {
             $.ajax({
                 type: "POST",
                 url: "api/courseinfo",
                 data: JSON.stringify({"code" : courseCode}),
                 success: (response) => {
-                    this.setState({"selectedCourseInfo" : JSON.parse(response)});
+                    this.setState({selectedCourseInfo : JSON.parse(response)});
                 }
             });
         });
@@ -663,7 +800,7 @@ class MainPage extends React.Component {
         let programName = generatePrettyProgramName(sequenceInfo.program, sequenceInfo.option, sequenceInfo.entryType, minTotalCredits);
 
         this.setState({
-            "loadingExport": true
+            loadingExport: true
         }, () =>{
             $.ajax({
                 type: "POST",
@@ -689,7 +826,7 @@ class MainPage extends React.Component {
 
                     saveAs(downloadUrl, "MySequence." + extension);
 
-                    this.setState({"loadingExport" : false});
+                    this.setState({loadingExport : false});
                 }
             });
         });
@@ -700,29 +837,27 @@ class MainPage extends React.Component {
      *  validates the sequence via backend API and update the page state accordingly
      */
     validateSequence(){
-        this.setState({
-            validationResults: {
-                issues: this.state.validationResults.issues,
-                warnings: this.state.validationResults.warnings,
-                isValid: this.state.validationResults.isValid,
-                isLoading: true
+        this.setState((prevState) => {
+            return {
+                validationResults: update(prevState.validationResults, {isLoading: {$set: true}})
             }
-        });
-        $.ajax({
-            type: "POST",
-            url: "api/validate",
-            data: JSON.stringify({"courseSequenceObject" : this.state.courseSequenceObject}),
-            success: (res) => {
-                let response = JSON.parse(res);
-                this.setState({
-                    validationResults: {
-                        issues: response.issues,
-                        warnings: response.warnings,
-                        isValid: response.isValid,
-                        isLoading: false
-                    }
-                });
-            }
+        }, () => {
+            $.ajax({
+                type: "POST",
+                url: "api/validate",
+                data: JSON.stringify({courseSequenceObject : this.state.courseSequenceObject}),
+                success: (res) => {
+                    let response = JSON.parse(res);
+                    this.setState({
+                        validationResults: {
+                            issues: response.issues,
+                            warnings: response.warnings,
+                            isValid: response.isValid,
+                            isLoading: false
+                        }
+                    });
+                }
+            });
         });
     }
 }

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -363,15 +363,18 @@ class MainPage extends React.Component {
      */
     addCourse(courseObj, toSemester){
         this.setState((prevState) => {
-            courseObj.id = generateUniqueKey(courseObj, toSemester.season, toSemester.yearIndex, 0, "", new Date().getTime());
-            courseObj.isElective = "false";
-            courseObj.electiveType = "";
+
+            let courseObjEditCommand = {
+                id: {$set: generateUniqueKey(courseObj, toSemester.season, toSemester.yearIndex, 0, "", new Date().getTime())},
+                isElective: {$set: "false"},
+                electiveType: {$set: ""}
+            };
 
             let addCommand = {
                 yearList: {
                     [toSemester.yearIndex]: {
                         [toSemester.season]: {
-                            courseList: {$splice: [[0, 0, courseObj]]}
+                            courseList: {$splice: [[0, 0, update(courseObj, courseObjEditCommand)]]}
                         }
                     }
                 }

--- a/src/main/webapp/babel-src/mainPage.js
+++ b/src/main/webapp/babel-src/mainPage.js
@@ -87,6 +87,7 @@ class MainPage extends React.Component {
         this.handleScroll = this.handleScroll.bind(this);
         this.showFeedbackBox = this.showFeedbackBox.bind(this);
         this.closeFeedBackBox = this.closeFeedBackBox.bind(this);
+        this.handleCourseClick = this.handleCourseClick.bind(this);
     }
 
     componentDidMount() {
@@ -228,8 +229,10 @@ class MainPage extends React.Component {
      *      param positions - array of objects indicating the absolute position of the course within the sequence
      */
     highlightCourses(positions){
-        this.setState({
-            highlightedCoursePositions: positions
+        this.setState((prevState) => {
+            return {
+                highlightedCoursePositions: JSON.parse(JSON.stringify(prevState.highlightedCoursePositions)).concat(positions)
+            }
         });
     }
 
@@ -237,9 +240,17 @@ class MainPage extends React.Component {
      *  function to call in the event that the user hovers out of a sequence validation results item
      *      param positions - array of objects indicating the absolute position of the course within the sequence
      */
-    unhighlightCourses(){
-        this.setState({
-            highlightedCoursePositions: []
+    unhighlightCourses(positions){
+        this.setState((prevState) => {
+            let newHighlightedPositions = [];
+            prevState.highlightedCoursePositions.forEach((highlightedPosition) => {
+                if(positions.indexOf(highlightedPosition) === -1){
+                    newHighlightedPositions.push(highlightedPosition);
+                }
+            });
+            return {
+                highlightedCoursePositions: newHighlightedPositions
+            }
         });
     }
 
@@ -437,6 +448,14 @@ class MainPage extends React.Component {
         });
     }
 
+    /*
+     */
+    handleCourseClick(){
+        this.setState({
+            detachIOPanel: window.scrollY > 80
+        });
+    }
+
     renderAppBarTitle() {
         let siteName = <div className="siteNameLabel">{UI_STRINGS.SITE_NAME}</div>;
         let betaLabel = <div className="betaLabel">{UI_STRINGS.BETA_LABEL}</div>;
@@ -481,7 +500,7 @@ class MainPage extends React.Component {
                         <div className="programPrettyName"><a href={sourceUrl} target="_blank">{programPrettyName}</a></div>
                         <SemesterTable courseSequenceObject={this.state.courseSequenceObject}
                                        highlightedCoursePositions={this.state.highlightedCoursePositions}
-                                       onSelectCourse={this.loadCourseInfo}
+                                       onSelectCourse={this.handleCourseClick}
                                        onOrListSelection={this.setOrListCourseSelected}
                                        onToggleWorkTerm={this.toggleWorkTerm}
                                        onMoveCourse={this.moveCourse}
@@ -492,7 +511,7 @@ class MainPage extends React.Component {
                         <div className="programPrettyName"><a href={sourceUrl} target="_blank">{programPrettyName}</a></div>
                         <SemesterList courseSequenceObject={this.state.courseSequenceObject}
                                       highlightedCoursePositions={this.state.highlightedCoursePositions}
-                                      onSelectCourse={this.loadCourseInfo}
+                                      onSelectCourse={this.handleCourseClick}
                                       onOrListSelection={this.setOrListCourseSelected}
                                       onToggleWorkTerm={this.toggleWorkTerm}
                                       onMoveCourse={this.moveCourse}

--- a/src/main/webapp/babel-src/orList.js
+++ b/src/main/webapp/babel-src/orList.js
@@ -39,8 +39,8 @@ class OrList extends React.Component {
     render() {
 
         let extraClassNames = [];
-        if(this.props.isBeingDragged) {
-            extraClassNames.push("beingDragged");
+        if(this.props.isHidden){
+            extraClassNames.push("isHidden");
         }
         if(this.props.isDraggable){
             extraClassNames.push("grabbable");

--- a/src/main/webapp/babel-src/orList.js
+++ b/src/main/webapp/babel-src/orList.js
@@ -39,6 +39,9 @@ class OrList extends React.Component {
         if(this.props.isHighlighted){
             extraClassNames.push("highlighted");
         }
+        if(this.props.isSelected){
+            extraClassNames.push("selected");
+        }
 
         let courseList = this.props.courseList;
         let position = this.props.position;

--- a/src/main/webapp/babel-src/orList.js
+++ b/src/main/webapp/babel-src/orList.js
@@ -32,8 +32,11 @@ class OrList extends React.Component {
 
     handleSelectedCourseClick(event, selectedCourseObj){
         event.stopPropagation();
-        let isElective = selectedCourseObj.isElective === "true";
-        this.props.onCourseClick(isElective ? "" : selectedCourseObj.code, this.props.position);
+        let code = undefined;
+        if(selectedCourseObj){
+            code = (selectedCourseObj.isElective === "true") ? "" : selectedCourseObj.code
+        }
+        this.props.onCourseClick(code, this.props.position);
     }
 
     render() {

--- a/src/main/webapp/babel-src/orList.js
+++ b/src/main/webapp/babel-src/orList.js
@@ -25,6 +25,15 @@ class OrList extends React.Component {
 
     constructor(props){
         super(props);
+
+        // functions that are passed as callbacks need to be bound to current class - see https://facebook.github.io/react/docs/handling-events.html
+        this.handleSelectedCourseClick = this.handleSelectedCourseClick.bind(this)
+    }
+
+    handleSelectedCourseClick(event, selectedCourseObj){
+        event.stopPropagation();
+        let isElective = selectedCourseObj.isElective === "true";
+        this.props.onCourseClick(isElective ? "" : selectedCourseObj.code, this.props.position);
     }
 
     render() {
@@ -46,7 +55,7 @@ class OrList extends React.Component {
         let courseList = this.props.courseList;
         let position = this.props.position;
 
-        return this.props.connectDragSource(renderOrListDiv(courseList, extraClassNames.join(" "), position, this.props.onCourseClick, this.props.onOrListSelection));
+        return this.props.connectDragSource(renderOrListDiv(courseList, extraClassNames.join(" "), position, this.handleSelectedCourseClick, this.props.onOrListSelection));
     }
 }
 

--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Toggle from 'material-ui/Toggle';
 
-import { UI_STRINGS, ITEM_TYPES } from "./util";
+import { UI_STRINGS, ITEM_TYPES, positionToString } from "./util";
 import Course from "./course";
 import OrList from "./orList";
 import { DropTarget } from 'react-dnd';
@@ -64,13 +64,14 @@ class SemesterBox extends React.Component {
                 "season": this.props.season,
                 "courseIndex": courseIndex
             };
+            let positionStyles = this.props.positionStyleMap[positionToString(position)];
             if(courseObj.length > 0){
                 let courseList = courseObj;
                 return (
                     <OrList courseList={courseList}
                             position={position}
-                            isHighlighted={this.arrayContainsPosition(this.props.highlightedCoursePositions, position)}
-                            isSelected={this.arrayContainsPosition(this.props.selectedCoursePositions, position)}
+                            isHighlighted={positionStyles && positionStyles.isHighlighted}
+                            isSelected={positionStyles && positionStyles.isSelected}
                             isDraggable={true}
                             onOrListSelection={this.props.onOrListSelection}
                             onCourseClick={this.props.onSelectCourse}
@@ -82,8 +83,8 @@ class SemesterBox extends React.Component {
                 return (
                     <Course courseObj={courseObj}
                             position={position}
-                            isHighlighted={this.arrayContainsPosition(this.props.highlightedCoursePositions, position)}
-                            isSelected={this.arrayContainsPosition(this.props.selectedCoursePositions, position)}
+                            isHighlighted={positionStyles && positionStyles.isHighlighted}
+                            isSelected={positionStyles && positionStyles.isSelected}
                             isDraggable={true}
                             onCourseClick={this.props.onSelectCourse}
                             onChangeDragState={this.props.onChangeDragState}

--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -36,18 +36,6 @@ class SemesterBox extends React.Component {
         this.handleWorkTermToggle = this.handleWorkTermToggle.bind(this);
     }
 
-    arrayContainsPosition(array, position){
-        for(let i = 0; i < array.length; i++){
-            let positionAtIndex = array[i];
-            if(positionAtIndex.yearIndex == position.yearIndex &&
-                positionAtIndex.season === position.season &&
-                positionAtIndex.courseIndex == position.courseIndex){
-                return true;
-            }
-        }
-        return false;
-    }
-
     handleWorkTermToggle(){
         this.props.onToggleWorkTerm(this.props.yearIndex, this.props.season);
     }

--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -32,10 +32,24 @@ class SemesterBox extends React.Component {
 
         // functions that are passed as callbacks need to be bound to current class - see https://facebook.github.io/react/docs/handling-events.html
         this.handleWorkTermToggle = this.handleWorkTermToggle.bind(this);
+        this.isPositionHighlighted = this.isPositionHighlighted.bind(this);
     }
 
     handleWorkTermToggle(){
         this.props.onToggleWorkTerm(this.props.yearIndex, this.props.season);
+    }
+
+    isPositionHighlighted(position) {
+        let highlightedPositions = this.props.highlightedCoursePositions;
+        for(let i = 0; i < highlightedPositions.length; i++){
+            let highlightedPosition = highlightedPositions[i];
+            if(highlightedPosition.yearIndex == position.yearIndex &&
+                highlightedPosition.season === position.season &&
+                highlightedPosition.courseIndex == position.courseListIndex){
+                return true;
+            }
+        }
+        return false;
     }
 
     renderCourseList(){
@@ -52,20 +66,12 @@ class SemesterBox extends React.Component {
                 "season": this.props.season,
                 "courseListIndex": courseIndex
             };
-            let isHighlighted = false;
-            this.props.highlightedCoursePositions.forEach((highlightedPosition) => {
-                if(highlightedPosition.yearIndex == position.yearIndex &&
-                   highlightedPosition.season === position.season &&
-                   highlightedPosition.courseIndex == courseIndex){
-                    isHighlighted = true;
-                }
-            });
             if(courseObj.length > 0){
                 let courseList = courseObj;
                 return (
                     <OrList courseList={courseList}
                             position={position}
-                            isHighlighted={isHighlighted}
+                            isHighlighted={this.isPositionHighlighted(position)}
                             isDraggable={true}
                             onOrListSelection={this.props.onOrListSelection}
                             onCourseClick={this.props.onSelectCourse}
@@ -77,7 +83,7 @@ class SemesterBox extends React.Component {
                 return (
                     <Course courseObj={courseObj}
                             position={position}
-                            isHighlighted={isHighlighted}
+                            isHighlighted={this.isPositionHighlighted(position)}
                             isDraggable={true}
                             onCourseClick={courseObj.isElective === "false" ? this.props.onSelectCourse : (() => {})}
                             onChangeDragState={this.props.onChangeDragState}

--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -32,24 +32,22 @@ class SemesterBox extends React.Component {
 
         // functions that are passed as callbacks need to be bound to current class - see https://facebook.github.io/react/docs/handling-events.html
         this.handleWorkTermToggle = this.handleWorkTermToggle.bind(this);
-        this.isPositionHighlighted = this.isPositionHighlighted.bind(this);
     }
 
-    handleWorkTermToggle(){
-        this.props.onToggleWorkTerm(this.props.yearIndex, this.props.season);
-    }
-
-    isPositionHighlighted(position) {
-        let highlightedPositions = this.props.highlightedCoursePositions;
-        for(let i = 0; i < highlightedPositions.length; i++){
-            let highlightedPosition = highlightedPositions[i];
-            if(highlightedPosition.yearIndex == position.yearIndex &&
-                highlightedPosition.season === position.season &&
-                highlightedPosition.courseIndex == position.courseListIndex){
+    arrayContainsPosition(array, position){
+        for(let i = 0; i < array.length; i++){
+            let positionAtIndex = array[i];
+            if(positionAtIndex.yearIndex == position.yearIndex &&
+                positionAtIndex.season === position.season &&
+                positionAtIndex.courseIndex == position.courseIndex){
                 return true;
             }
         }
         return false;
+    }
+
+    handleWorkTermToggle(){
+        this.props.onToggleWorkTerm(this.props.yearIndex, this.props.season);
     }
 
     renderCourseList(){
@@ -64,14 +62,15 @@ class SemesterBox extends React.Component {
             let position = {
                 "yearIndex": this.props.yearIndex,
                 "season": this.props.season,
-                "courseListIndex": courseIndex
+                "courseIndex": courseIndex
             };
             if(courseObj.length > 0){
                 let courseList = courseObj;
                 return (
                     <OrList courseList={courseList}
                             position={position}
-                            isHighlighted={this.isPositionHighlighted(position)}
+                            isHighlighted={this.arrayContainsPosition(this.props.highlightedCoursePositions, position)}
+                            isSelected={this.arrayContainsPosition(this.props.selectedCoursePositions, position)}
                             isDraggable={true}
                             onOrListSelection={this.props.onOrListSelection}
                             onCourseClick={this.props.onSelectCourse}
@@ -83,9 +82,10 @@ class SemesterBox extends React.Component {
                 return (
                     <Course courseObj={courseObj}
                             position={position}
-                            isHighlighted={this.isPositionHighlighted(position)}
+                            isHighlighted={this.arrayContainsPosition(this.props.highlightedCoursePositions, position)}
+                            isSelected={this.arrayContainsPosition(this.props.selectedCoursePositions, position)}
                             isDraggable={true}
-                            onCourseClick={courseObj.isElective === "false" ? this.props.onSelectCourse : (() => {})}
+                            onCourseClick={this.props.onSelectCourse}
                             onChangeDragState={this.props.onChangeDragState}
                             key={courseObj.id}/>
                 );
@@ -151,7 +151,7 @@ let semesterTarget = {
         let newPosition = {
             "yearIndex": props.yearIndex,
             "season": props.season,
-            "courseListIndex": 0
+            "courseIndex": 0
         };
 
         // no course position means the course was dragged from the IOPanel

--- a/src/main/webapp/babel-src/semesterBox.js
+++ b/src/main/webapp/babel-src/semesterBox.js
@@ -17,10 +17,12 @@ import { DropTarget } from 'react-dnd';
  *
  *  season - string which represents the season during which the semester in question occurs
  *
+ *  positionsBeingDragged - the positions of the items that are currently being dragged by the user
+ *
  *  onSelectCourse - see MainPage.loadCourseInfo
  *  onOrListSelection - see MainPage.setOrListCourseSelected
  *  onToggleWorkTerm - see MainPage.toggleWorkTerm
- *  onMoveCourse - see MainPage.moveCourse
+ *  onMoveCourses - see MainPage.moveCourses
  *  onAddCourse - see MainPage.addCourse
  *  onChangeDragState - see MainPage.enableGarbage
  *
@@ -64,14 +66,15 @@ class SemesterBox extends React.Component {
                 "season": this.props.season,
                 "courseIndex": courseIndex
             };
-            let positionStyles = this.props.positionStyleMap[positionToString(position)];
+            let itemStyles = this.props.positionStyleMap[positionToString(position)];
             if(courseObj.length > 0){
                 let courseList = courseObj;
                 return (
                     <OrList courseList={courseList}
                             position={position}
-                            isHighlighted={positionStyles && positionStyles.isHighlighted}
-                            isSelected={positionStyles && positionStyles.isSelected}
+                            isHighlighted={itemStyles && itemStyles.isHighlighted}
+                            isSelected={itemStyles && itemStyles.isSelected}
+                            isHidden={itemStyles && itemStyles.isHidden}
                             isDraggable={true}
                             onOrListSelection={this.props.onOrListSelection}
                             onCourseClick={this.props.onSelectCourse}
@@ -83,8 +86,9 @@ class SemesterBox extends React.Component {
                 return (
                     <Course courseObj={courseObj}
                             position={position}
-                            isHighlighted={positionStyles && positionStyles.isHighlighted}
-                            isSelected={positionStyles && positionStyles.isSelected}
+                            isHighlighted={itemStyles && itemStyles.isHighlighted}
+                            isSelected={itemStyles && itemStyles.isSelected}
+                            isHidden={itemStyles && itemStyles.isHidden}
                             isDraggable={true}
                             onCourseClick={this.props.onSelectCourse}
                             onChangeDragState={this.props.onChangeDragState}
@@ -125,41 +129,22 @@ let semesterTarget = {
     hover(props, monitor, component) {
     },
     canDrop(props, monitor){
-
-        if(monitor.getItem().position && monitor.getItem().position.season === props.season && monitor.getItem().position.yearIndex === props.yearIndex){
-            return false;
-        }
-
-        let canDrop = true;
-
-        if (monitor.getItemType() === ITEM_TYPES.COURSE) {
-
-            for(let i = 0; i < props.semester.courseList.length; i++){
-                let tCourse = props.semester.courseList[i];
-                if(tCourse.code && tCourse.code === monitor.getItem().courseObj.code){
-                    canDrop = false;
-                }
-            }
-
-        }
-
-        return canDrop;
+        return true;
     },
     drop(props, monitor, component){
 
         let draggedItem = monitor.getItem();
 
-        let newPosition = {
+        let toSemester = {
             "yearIndex": props.yearIndex,
-            "season": props.season,
-            "courseIndex": 0
+            "season": props.season
         };
 
         // no course position means the course was dragged from the IOPanel
         if(!draggedItem.position){
-            props.onAddCourse(draggedItem.courseObj, newPosition);
+            props.onAddCourse(draggedItem.courseObj, toSemester);
         } else {
-            props.onMoveCourse(draggedItem.position, newPosition);
+            props.onMoveCourses(props.positionsBeingDragged, toSemester);
         }
     }
 };

--- a/src/main/webapp/babel-src/semesterList.js
+++ b/src/main/webapp/babel-src/semesterList.js
@@ -14,7 +14,7 @@ import {SEASON_NAMES, SEASON_NAMES_PRETTY, LOADING_ICON_TYPES} from "./util";
  *  onSelectCourse - see MainPage.handleCourseClick
  *  onOrListSelection - see MainPage.setOrListCourseSelected
  *  onToggleWorkTerm - see MainPage.toggleWorkTerm
- *  onMoveCourse - see MainPage.moveCourse
+ *  onMoveCourses - see MainPage.moveCourses
  *  onChangeDragState - see MainPage.enableGarbage
  *
  */
@@ -38,10 +38,11 @@ export class SemesterList extends React.Component {
                                  season={season}
                                  semester={yearList[yearIndex][season]}
                                  positionStyleMap={this.props.positionStyleMap}
+                                 positionsBeingDragged={this.props.positionsBeingDragged}
                                  onSelectCourse={this.props.onSelectCourse}
                                  onOrListSelection={this.props.onOrListSelection}
                                  onToggleWorkTerm={this.props.onToggleWorkTerm}
-                                 onMoveCourse={this.props.onMoveCourse}
+                                 onMoveCourses={this.props.onMoveCourses}
                                  onAddCourse={this.props.onAddCourse}
                                  onChangeDragState={this.props.onChangeDragState}/>
                 </div>

--- a/src/main/webapp/babel-src/semesterList.js
+++ b/src/main/webapp/babel-src/semesterList.js
@@ -12,7 +12,7 @@ import {SEASON_NAMES, SEASON_NAMES_PRETTY, LOADING_ICON_TYPES} from "./util";
  *  courseSequenceObject - the json object which contains all necessary data for the sequence we want to display
  *  highlightedCoursePositions - the list of sequence positions whose course should get highlighted
  *
- *  onSelectCourse - see MainPage.loadCourseInfo
+ *  onSelectCourse - see MainPage.handleCourseClick
  *  onOrListSelection - see MainPage.setOrListCourseSelected
  *  onToggleWorkTerm - see MainPage.toggleWorkTerm
  *  onMoveCourse - see MainPage.moveCourse
@@ -20,6 +20,8 @@ import {SEASON_NAMES, SEASON_NAMES_PRETTY, LOADING_ICON_TYPES} from "./util";
  *
  */
 export class SemesterList extends React.Component {
+
+
 
     generateListBody(){
 
@@ -37,6 +39,7 @@ export class SemesterList extends React.Component {
                                  season={season}
                                  semester={yearList[yearIndex][season]}
                                  highlightedCoursePositions={this.props.highlightedCoursePositions}
+                                 selectedCoursePositions={this.props.selectedCoursePositions}
                                  onSelectCourse={this.props.onSelectCourse}
                                  onOrListSelection={this.props.onOrListSelection}
                                  onToggleWorkTerm={this.props.onToggleWorkTerm}

--- a/src/main/webapp/babel-src/semesterList.js
+++ b/src/main/webapp/babel-src/semesterList.js
@@ -10,7 +10,6 @@ import {SEASON_NAMES, SEASON_NAMES_PRETTY, LOADING_ICON_TYPES} from "./util";
  *  Expects props:
  *
  *  courseSequenceObject - the json object which contains all necessary data for the sequence we want to display
- *  highlightedCoursePositions - the list of sequence positions whose course should get highlighted
  *
  *  onSelectCourse - see MainPage.handleCourseClick
  *  onOrListSelection - see MainPage.setOrListCourseSelected
@@ -38,8 +37,7 @@ export class SemesterList extends React.Component {
                     <SemesterBox yearIndex={yearIndex}
                                  season={season}
                                  semester={yearList[yearIndex][season]}
-                                 highlightedCoursePositions={this.props.highlightedCoursePositions}
-                                 selectedCoursePositions={this.props.selectedCoursePositions}
+                                 positionStyleMap={this.props.positionStyleMap}
                                  onSelectCourse={this.props.onSelectCourse}
                                  onOrListSelection={this.props.onOrListSelection}
                                  onToggleWorkTerm={this.props.onToggleWorkTerm}

--- a/src/main/webapp/babel-src/semesterTable.js
+++ b/src/main/webapp/babel-src/semesterTable.js
@@ -10,7 +10,6 @@ import { SEASON_NAMES, SEASON_NAMES_PRETTY, LOADING_ICON_TYPES } from "./util";
  *  Expects props:
  *
  *  courseSequenceObject - the json object which contains all necessary data for the sequence we want to display
- *  highlightedCoursePositions - the list of sequence positions whose course should get highlighted
  *
  *  onSelectCourse - see MainPage.handleCourseClick
  *  onOrListSelection - see MainPage.setOrListCourseSelected
@@ -37,8 +36,7 @@ export class SemesterTable extends React.Component {
                         <SemesterBox yearIndex={yearIndex}
                                      season={season}
                                      semester={yearList[yearIndex][season]}
-                                     highlightedCoursePositions={this.props.highlightedCoursePositions}
-                                     selectedCoursePositions={this.props.selectedCoursePositions}
+                                     positionStyleMap={this.props.positionStyleMap}
                                      onSelectCourse={this.props.onSelectCourse}
                                      onOrListSelection={this.props.onOrListSelection}
                                      onToggleWorkTerm={this.props.onToggleWorkTerm}

--- a/src/main/webapp/babel-src/semesterTable.js
+++ b/src/main/webapp/babel-src/semesterTable.js
@@ -12,7 +12,7 @@ import { SEASON_NAMES, SEASON_NAMES_PRETTY, LOADING_ICON_TYPES } from "./util";
  *  courseSequenceObject - the json object which contains all necessary data for the sequence we want to display
  *  highlightedCoursePositions - the list of sequence positions whose course should get highlighted
  *
- *  onSelectCourse - see MainPage.loadCourseInfo
+ *  onSelectCourse - see MainPage.handleCourseClick
  *  onOrListSelection - see MainPage.setOrListCourseSelected
  *  onToggleWorkTerm - see MainPage.toggleWorkTerm
  *  onMoveCourse - see MainPage.moveCourse
@@ -38,6 +38,7 @@ export class SemesterTable extends React.Component {
                                      season={season}
                                      semester={yearList[yearIndex][season]}
                                      highlightedCoursePositions={this.props.highlightedCoursePositions}
+                                     selectedCoursePositions={this.props.selectedCoursePositions}
                                      onSelectCourse={this.props.onSelectCourse}
                                      onOrListSelection={this.props.onOrListSelection}
                                      onToggleWorkTerm={this.props.onToggleWorkTerm}

--- a/src/main/webapp/babel-src/semesterTable.js
+++ b/src/main/webapp/babel-src/semesterTable.js
@@ -14,7 +14,7 @@ import { SEASON_NAMES, SEASON_NAMES_PRETTY, LOADING_ICON_TYPES } from "./util";
  *  onSelectCourse - see MainPage.handleCourseClick
  *  onOrListSelection - see MainPage.setOrListCourseSelected
  *  onToggleWorkTerm - see MainPage.toggleWorkTerm
- *  onMoveCourse - see MainPage.moveCourse
+ *  onMoveCourses - see MainPage.moveCourses
  *  onChangeDragState - see MainPage.enableGarbage
  *
 */
@@ -37,10 +37,11 @@ export class SemesterTable extends React.Component {
                                      season={season}
                                      semester={yearList[yearIndex][season]}
                                      positionStyleMap={this.props.positionStyleMap}
+                                     positionsBeingDragged={this.props.positionsBeingDragged}
                                      onSelectCourse={this.props.onSelectCourse}
                                      onOrListSelection={this.props.onOrListSelection}
                                      onToggleWorkTerm={this.props.onToggleWorkTerm}
-                                     onMoveCourse={this.props.onMoveCourse}
+                                     onMoveCourses={this.props.onMoveCourses}
                                      onAddCourse={this.props.onAddCourse}
                                      onChangeDragState={this.props.onChangeDragState}/>
                     </td>

--- a/src/main/webapp/babel-src/sequenceValidationCard.js
+++ b/src/main/webapp/babel-src/sequenceValidationCard.js
@@ -136,7 +136,7 @@ export class SequenceValidationCard extends React.Component {
                               message={item.message}
                               key={index}
                               onMouseEnter={() => this.props.onMouseEnterItem(item.positionsToHighlight)}
-                              onMouseLeave={() => this.props.onMouseLeaveItem()}/>
+                              onMouseLeave={() => this.props.onMouseLeaveItem(item.positionsToHighlight)}/>
                 ))}
             </CardText>
         );

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -296,13 +296,13 @@ export function saveAs(uri, filename) {
 export function generateUniqueKeys(yearList){
     yearList.forEach((year, yearIndex) => {
         SEASON_NAMES.forEach((season) => {
-            year[season].courseList.forEach((courseObj, courseListIndex) => {
+            year[season].courseList.forEach((courseObj, courseIndex) => {
                 if(courseObj.length > 0){
                     courseObj.forEach((courseOrObj, orListIndex) => {
-                        courseOrObj.id = generateUniqueKey(courseOrObj, season, yearIndex, courseListIndex, orListIndex);
+                        courseOrObj.id = generateUniqueKey(courseOrObj, season, yearIndex, courseIndex, orListIndex);
                     });
                 } else {
-                    courseObj.id = generateUniqueKey(courseObj, season, yearIndex, courseListIndex, "");
+                    courseObj.id = generateUniqueKey(courseObj, season, yearIndex, courseIndex, "");
                 }
             });
         });
@@ -314,9 +314,9 @@ export function generateUniqueKeys(yearList){
  *  Form unique ID by combing course code/electiveType with its current position in the yearList
  *  If the course changes its position within the yearList, we do NOT want this id value to change, so we only call this once.
  */
-export function generateUniqueKey(courseObj, season, yearIndex, courseListIndex, orListIndex){
+export function generateUniqueKey(courseObj, season, yearIndex, courseIndex, orListIndex){
     let id = (courseObj.isElective === "true") ? courseObj.electiveType : courseObj.code;
-    id += season + yearIndex + courseListIndex + orListIndex;
+    id += season + yearIndex + courseIndex + orListIndex;
     return id;
 }
 
@@ -338,7 +338,7 @@ export function renderOrListDiv(courseList, extraClassNames, position, clickHand
                                 listClickHandler({
                                     "yearIndex": position.yearIndex,
                                     "season": position.season,
-                                    "courseListIndex": position.courseListIndex,
+                                    "courseIndex": position.courseIndex,
                                     "orListIndex": courseIndex
                                 });
                             })}
@@ -362,7 +362,7 @@ export function renderCourseDiv(courseObj, extraClassNames, clickHandler){
     return (
         <div className={"course " + extraClassNames} title={courseObj.name || UI_STRINGS.ELECTIVE_COURSE_TOOLTIP} onClick={clickHandler || (() => {})}>
             <div className="courseCode">
-                { (courseObj.isElective === "true") ? (courseObj.electiveType + " Elective") : courseObj.code}
+                { (courseObj.isElective === "true") ? (courseObj.electiveType + " Elective") : courseObj.code }
             </div>
             <div className="courseCredits">{courseObj.credits}</div>
         </div>

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -419,6 +419,9 @@ function renderSelectedOrCourse(courseList, clickHandler){
         clickHandler(event, selectedCourse);
     };
 
-    return (!selectedCourse) ? <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP} onClick={handleSelectedCourseClick}>{UI_STRINGS.LIST_NONE_SELECTED}</div> :
+    return (!selectedCourse) ? <div className="orListNoneSelected"
+                                    title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP}
+                                    onClick={handleSelectedCourseClick}>{UI_STRINGS.LIST_NONE_SELECTED}
+                               </div> :
                                renderCourseDiv(selectedCourse, "", handleSelectedCourseClick);
 }

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -18,6 +18,12 @@ export const FEEDBACK_CHAR_LIMIT = 1000;
 export const FEEDBACK_SNACKBAR_AUTOHIDE_DURATION = 4000;
 export const FEEDBACK_ROWS_MAX = 10;
 
+export const KEY_CODES = {
+    SHIFT: 16,
+    CTRL: 17,
+    Z: 90
+};
+
 // Item types used for DND
 export const ITEM_TYPES = {
     COURSE: "Course",

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -316,8 +316,21 @@ export function generateUniqueKeys(yearList){
  */
 export function generateUniqueKey(courseObj, season, yearIndex, courseIndex, orListIndex){
     let id = (courseObj.isElective === "true") ? courseObj.electiveType : courseObj.code;
-    id += season + yearIndex + courseIndex + orListIndex;
+    id += positionToString({
+        season: season,
+        yearIndex: yearIndex,
+        courseIndex: courseIndex,
+        orListIndex: orListIndex
+    });
     return id;
+}
+
+/*
+ * Generate a string from a position object
+ *     position: position of the course in the sequence, possibly within an orList
+ */
+export function positionToString(position){
+    return position.season + position.yearIndex + position.courseIndex + (position.orListIndex || "");
 }
 
 /*
@@ -369,22 +382,24 @@ export function renderCourseDiv(courseObj, extraClassNames, clickHandler){
     );
 }
 
+/*
+ *  Render a course div to the right of the drop down arrow within an orList item.
+ *  Represents the currently selected course of the orList.
+ *      courseList: the list of courses that the orList contains
+ *      clickHandler: function to call when the selected course div is clicked
+ */
 function renderSelectedOrCourse(courseList, clickHandler){
 
     let selectedCourse = undefined;
-    let selectedIndex = -1;
 
-    courseList.forEach((courseObj, orListIndex) => {
-        if(courseObj.isSelected){
-            selectedCourse = courseObj;
-            selectedIndex = orListIndex;
-
-            if(selectedCourse.isElective === "true"){
-                clickHandler = () => {};
-            }
-        }
+    courseList.forEach((courseObj) => {
+        (courseObj.isSelected) && (selectedCourse = courseObj);
     });
 
+    let handleSelectedCourseClick = (event) => {
+        clickHandler(event, selectedCourse);
+    };
+
     return (!selectedCourse) ? <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP}>{UI_STRINGS.LIST_NONE_SELECTED}</div> :
-                               renderCourseDiv(selectedCourse, "", () => clickHandler(selectedCourse.code));
+                               renderCourseDiv(selectedCourse, "", handleSelectedCourseClick);
 }

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -419,6 +419,6 @@ function renderSelectedOrCourse(courseList, clickHandler){
         clickHandler(event, selectedCourse);
     };
 
-    return (!selectedCourse) ? <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP}>{UI_STRINGS.LIST_NONE_SELECTED}</div> :
+    return (!selectedCourse) ? <div title={UI_STRINGS.ORLIST_CHOICE_TOOLTIP} onClick={handleSelectedCourseClick}>{UI_STRINGS.LIST_NONE_SELECTED}</div> :
                                renderCourseDiv(selectedCourse, "", handleSelectedCourseClick);
 }

--- a/src/main/webapp/babel-src/util.js
+++ b/src/main/webapp/babel-src/util.js
@@ -229,15 +229,15 @@ export function generatePrettyProgramName(program, option, entryType, minTotalCr
 export const courseDragSource = {
     beginDrag(props, monitor, component) {
 
-        props.onChangeDragState && props.onChangeDragState(true);
+        props.onChangeDragState && props.onChangeDragState(true, props.position, props.courseObj);
 
         return {
-            "courseObj": props.courseObj,
-            "position": props.position
+            courseObj: props.courseObj,
+            position: props.position
         };
     },
     endDrag(props, monitor, component){
-        props.onChangeDragState && props.onChangeDragState(false);
+        props.onChangeDragState && props.onChangeDragState(false, props.position);
     },
     canDrag(props, monitor){
         return props.isDraggable;
@@ -250,15 +250,15 @@ export const courseDragSource = {
 export const orListDragSource = {
     beginDrag(props, monitor, component) {
 
-        props.onChangeDragState && props.onChangeDragState(true);
+        props.onChangeDragState && props.onChangeDragState(true, props.position);
 
         return {
-            "courseList": props.courseList,
-            "position": props.position
+            courseList: props.courseList,
+            position: props.position
         };
     },
     endDrag(props, monitor, component){
-        props.onChangeDragState && props.onChangeDragState(false);
+        props.onChangeDragState && props.onChangeDragState(false, props.position);
     },
     canDrag(props, monitor){
         return props.isDraggable;
@@ -297,7 +297,6 @@ export function saveAs(uri, filename) {
  *  This is helpful for react to properly respond to changes and
  *  it is especially necessary for the react-dnd module to work properly
  *
- *  The unique ID is formed by appending the course code to the
  */
 export function generateUniqueKeys(yearList){
     yearList.forEach((year, yearIndex) => {
@@ -320,7 +319,7 @@ export function generateUniqueKeys(yearList){
  *  Form unique ID by combing course code/electiveType with its current position in the yearList
  *  If the course changes its position within the yearList, we do NOT want this id value to change, so we only call this once.
  */
-export function generateUniqueKey(courseObj, season, yearIndex, courseIndex, orListIndex){
+export function generateUniqueKey(courseObj, season, yearIndex, courseIndex, orListIndex, timestamp){
     let id = (courseObj.isElective === "true") ? courseObj.electiveType : courseObj.code;
     id += positionToString({
         season: season,
@@ -328,6 +327,7 @@ export function generateUniqueKey(courseObj, season, yearIndex, courseIndex, orL
         courseIndex: courseIndex,
         orListIndex: orListIndex
     });
+    (timestamp) && (id += (" " + timestamp));
     return id;
 }
 
@@ -336,7 +336,20 @@ export function generateUniqueKey(courseObj, season, yearIndex, courseIndex, orL
  *     position: position of the course in the sequence, possibly within an orList
  */
 export function positionToString(position){
-    return position.season + position.yearIndex + position.courseIndex + (position.orListIndex || "");
+    return [position.season, position.yearIndex, position.courseIndex].join(" ");
+}
+
+/*
+ * Generate a position from a position string
+ *     positionString: position of the course in the sequence, represented as a string
+ */
+export function parsePositionString(positionString){
+    let subStrings = positionString.split(" ");
+    return {
+        season: subStrings[0],
+        yearIndex: parseInt(subStrings[1]),
+        courseIndex: parseInt(subStrings[2])
+    };
 }
 
 /*

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -297,7 +297,7 @@
 }
 
 .course.highlighted, .orList.highlighted {
-    border-color: #f5bb2b;
+    border-color: #6c1540;
 }
 
 .validationListIcon, .validationMessage {

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -82,8 +82,8 @@
 /* Styling for SemesterList */
 
 .semesterList {
-    border: 1px solid #DDDDDD;
-    border-radius: 5px;
+    border: none;
+    box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
     display: inline-block;
     margin-bottom: 20px;
     width: 100%;
@@ -129,7 +129,7 @@
     cursor: pointer;
     width: 160px;
     margin: 6px auto;
-    border-radius: 5px;
+    border-radius: 12px;
     border: 1px solid #DDDDDD;
     background-color: white;
     font-size: 14px;
@@ -145,7 +145,7 @@
     background-color: #D3D3D3;
 }
 
-.beingDragged {
+.isHidden {
     opacity: 0;
 }
 
@@ -160,7 +160,7 @@
     width: 160px;
     margin: 6px auto;
     border: 1px solid #DDDDDD;
-    border-radius: 5px;
+    border-radius: 12px;
 }
 
 .orList .course {
@@ -181,20 +181,28 @@
 .orList .input-group-addon > div {
     height: 22px;
     padding-top: 5px;
-    border-radius: 4px;
+    border-radius: 12px;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
 }
 
 .orList button {
     padding: 1px 8px;
-    background-color: transparent;
+    background-color: white;
     border: none;
     border-right: 1px solid #DDDDDD;
+    border-radius: 12px;
 }
 
-.orList button:hover, .orList button:active {
-    background-color: inherit;
+.orList > .input-group-btn > button.btn-default:hover,
+.orList > .input-group-btn > button.btn-default:focus,
+.orList > .open > button.btn-default {
+    border-color: #DDDDDD;
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.orList button:active:focus {
+    outline: none;
 }
 
 .orList .caret {}
@@ -292,8 +300,12 @@
     transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 }
 
-.validationListItem:hover, .course.selected, .orList.selected {
+.validationListItem:hover {
     background-color: rgba(0, 0, 0, 0.1);
+}
+
+.course.selected, .orList.selected {
+    border-color: #f5bb2b;
 }
 
 .course.highlighted, .orList.highlighted {
@@ -345,7 +357,7 @@
 /* Special styling for DND */
 
 .dragPreview {
-    margin: 0;
+    margin: 6px 0;
 }
 
 .textSelectionOff {

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -292,8 +292,12 @@
     transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 }
 
-.validationListItem:hover, .course.highlighted, .orList.highlighted {
+.validationListItem:hover, .course.selected, .orList.selected {
     background-color: rgba(0, 0, 0, 0.1);
+}
+
+.course.highlighted, .orList.highlighted {
+    border-color: #f5bb2b;
 }
 
 .validationListIcon, .validationMessage {

--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -137,11 +137,11 @@
     color: #333333;
 }
 
-.course:hover {
+.course:hover, .orListNoneSelected:hover {
     background-color: #E6E6E6;
 }
 
-.course:active {
+.course:active, .orListNoneSelected:active {
     background-color: #D3D3D3;
 }
 
@@ -203,6 +203,10 @@
 
 .orList button:active:focus {
     outline: none;
+}
+
+.orListNoneSelected {
+    background-color: white;
 }
 
 .orList .caret {}


### PR DESCRIPTION
resolves #139 

## Summary

- Changed style of highlighted courses (red border instead of gray background)
- Added ability to select courses by clicking on them (select multiple with CTRL+click). Clicking anywhere other than on a course will unselect all courses
- When you drag courses now, all currently selected courses will be included in the drag so you can move/remove them all with a single drag action
- Rewrote most of the state-updating functions to use a library called immutability-helper in order to improve performance
- Did a major refactor of mainPage.js so the diffs will be very ugly

## Test

Deployed to [d](http://www.conucourseplanner.online/courseplannerd/)